### PR TITLE
Redesign portfolio with dark hero layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# perfil_portfolio
+# Perfil Profissional · Leonardo Fonseca Pontes
+
+Site estático que apresenta o perfil profissional de Leonardo Fonseca Pontes, com
+informações de carreira, competências, certificações e canais de contato.
+
+## Estrutura
+
+- `index.html` — página principal do portfólio.
+- `assets/css/styles.css` — estilos globais do site.
+
+## Como visualizar
+
+1. Instale um servidor HTTP simples (por exemplo, utilizando Python).
+2. Execute o comando abaixo na raiz do projeto:
+
+   ```bash
+   python -m http.server 8000
+   ```
+
+3. Acesse <http://localhost:8000> no navegador.
+
+O site é responsivo e pode ser visualizado em diferentes tamanhos de tela.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,530 @@
+:root {
+  --color-background: #050816;
+  --color-surface: rgba(21, 26, 46, 0.9);
+  --color-surface-alt: rgba(12, 16, 32, 0.85);
+  --color-surface-strong: rgba(255, 255, 255, 0.05);
+  --color-text: #f5f8ff;
+  --color-text-muted: rgba(229, 233, 255, 0.7);
+  --color-accent: #f6b73c;
+  --color-accent-soft: rgba(246, 183, 60, 0.18);
+  --color-border: rgba(255, 255, 255, 0.12);
+  --gradient-hero: radial-gradient(circle at 20% 20%, rgba(246, 183, 60, 0.25), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(72, 113, 248, 0.3), transparent 55%),
+    linear-gradient(135deg, rgba(9, 12, 28, 0.95), rgba(5, 8, 22, 0.95));
+  --shadow-soft: 0 24px 60px rgba(3, 6, 18, 0.65);
+  --shadow-panel: 0 22px 45px rgba(3, 5, 15, 0.55);
+  --radius-lg: 32px;
+  --radius-md: 20px;
+  --radius-sm: 14px;
+  --container-width: min(1160px, 92vw);
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--color-background);
+  color: var(--color-text);
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+p {
+  margin: 0 0 1rem;
+  color: var(--color-text-muted);
+}
+
+h1,
+h2,
+h3,
+h4 {
+  margin: 0 0 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.2;
+}
+
+ul {
+  margin: 0 0 1.2rem 1.25rem;
+  padding: 0;
+  color: var(--color-text-muted);
+}
+
+li + li {
+  margin-top: 0.45rem;
+}
+
+.container {
+  width: var(--container-width);
+  margin: 0 auto;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(14px);
+  background: rgba(5, 8, 22, 0.85);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.topbar__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+  gap: 1rem;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand__monogram {
+  display: grid;
+  place-items: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(246, 183, 60, 0.32), rgba(91, 128, 255, 0.32));
+  color: var(--color-text);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.brand__name {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.brand__role {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+}
+
+.menu {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-size: 0.95rem;
+}
+
+.menu a {
+  color: var(--color-text-muted);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.menu a:hover,
+.menu a:focus {
+  color: var(--color-text);
+}
+
+.hero {
+  padding: 5.5rem 0 4rem;
+  background: var(--gradient-hero);
+}
+
+.hero__inner {
+  display: grid;
+  gap: 3rem;
+  align-items: start;
+}
+
+.hero__profile h1 {
+  font-size: clamp(2.2rem, 3.9vw, 3.4rem);
+  margin-bottom: 1.25rem;
+}
+
+.hero__profile > p {
+  font-size: 1.05rem;
+  max-width: 520px;
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-bottom: 1.25rem;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 2rem 0 2.5rem;
+}
+
+.hero__stats {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.stat-card {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-md);
+  padding: 1.4rem 1.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow-soft);
+}
+
+.stat-card__value {
+  margin: 0;
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: var(--color-accent);
+}
+
+.stat-card__label {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
+.hero__panel {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 2.5rem 2.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow-panel);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero__panel::after {
+  content: '';
+  position: absolute;
+  inset: auto -40% -40% auto;
+  width: 220px;
+  height: 220px;
+  background: radial-gradient(circle, rgba(246, 183, 60, 0.28), transparent 65%);
+  pointer-events: none;
+}
+
+.hero__avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 32px;
+  background: linear-gradient(145deg, rgba(246, 183, 60, 0.65), rgba(91, 128, 255, 0.45));
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+  font-weight: 700;
+  color: rgba(5, 8, 22, 0.9);
+  margin-bottom: 2rem;
+}
+
+.hero__details {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.detail__label {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(229, 233, 255, 0.52);
+  margin-bottom: 0.5rem;
+}
+
+.detail__value {
+  color: var(--color-text);
+  font-size: 1rem;
+  font-weight: 500;
+  word-break: break-word;
+}
+
+.section {
+  padding: 5rem 0;
+  position: relative;
+}
+
+.section--accent {
+  background: linear-gradient(160deg, rgba(15, 19, 38, 0.85), rgba(7, 10, 24, 0.85));
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.section--highlight {
+  background: radial-gradient(circle at 30% 20%, rgba(246, 183, 60, 0.22), rgba(5, 8, 22, 0.94));
+}
+
+.section__content {
+  display: grid;
+  gap: 3rem;
+}
+
+.section__header {
+  max-width: 680px;
+}
+
+.section__eyebrow {
+  display: inline-block;
+  margin-bottom: 1rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(229, 233, 255, 0.45);
+}
+
+.feature-grid {
+  display: grid;
+  gap: 1.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.feature-card {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-md);
+  padding: 1.75rem 1.9rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.timeline {
+  position: relative;
+  display: grid;
+  gap: 2.75rem;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 22px;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(246, 183, 60, 0.7), rgba(91, 128, 255, 0.2));
+}
+
+.timeline__item {
+  padding: 0 0 0 4.5rem;
+  position: relative;
+}
+
+.timeline__item::before {
+  content: '';
+  position: absolute;
+  top: 6px;
+  left: 12px;
+  width: 20px;
+  height: 20px;
+  border-radius: 10px;
+  border: 3px solid rgba(5, 8, 22, 0.85);
+  background: linear-gradient(135deg, rgba(246, 183, 60, 0.9), rgba(91, 128, 255, 0.7));
+  box-shadow: 0 0 0 6px rgba(246, 183, 60, 0.1);
+}
+
+.timeline__meta h3 {
+  margin-bottom: 0.4rem;
+}
+
+.timeline__period {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(246, 183, 60, 0.85);
+  font-size: 0.8rem;
+}
+
+.timeline__location {
+  margin: 0 0 1rem;
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.timeline__summary {
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+
+.timeline h4 {
+  font-size: 0.95rem;
+  margin-top: 1.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(229, 233, 255, 0.55);
+}
+
+.competency-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.competency-card {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-md);
+  padding: 1.8rem 2rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.certification-list {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.certification-card {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-md);
+  padding: 1.7rem 1.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow: var(--shadow-soft);
+}
+
+.callout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.callout__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.9rem 1.8rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.button {
+  background: linear-gradient(135deg, #f6b73c, #f9cf6d);
+  color: #120a02;
+  box-shadow: 0 16px 32px rgba(246, 183, 60, 0.28);
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 42px rgba(246, 183, 60, 0.35);
+}
+
+.button--ghost {
+  background: transparent;
+  border-color: rgba(246, 183, 60, 0.4);
+  color: var(--color-text);
+  box-shadow: none;
+}
+
+.button--ghost:hover,
+.button--ghost:focus {
+  background: rgba(246, 183, 60, 0.12);
+  color: var(--color-text);
+}
+
+.footer {
+  padding: 2.5rem 0;
+  text-align: center;
+  background: rgba(4, 6, 16, 0.95);
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.footer__content p {
+  margin: 0;
+  color: rgba(229, 233, 255, 0.55);
+  font-size: 0.9rem;
+}
+
+@media (min-width: 900px) {
+  .hero__inner {
+    grid-template-columns: 1.3fr 0.9fr;
+  }
+}
+
+@media (max-width: 860px) {
+  .menu {
+    display: none;
+  }
+
+  .hero__panel {
+    order: -1;
+  }
+
+  .hero__panel,
+  .hero__profile {
+    width: min(640px, 100%);
+    margin-inline: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar__inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero {
+    padding: 4rem 0 3rem;
+  }
+
+  .timeline::before {
+    left: 16px;
+  }
+
+  .timeline__item {
+    padding-left: 3.5rem;
+  }
+
+  .timeline__item::before {
+    left: 6px;
+  }
+
+  .callout {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .callout__actions,
+  .hero__actions {
+    width: 100%;
+  }
+
+  .button,
+  .button--ghost {
+    width: 100%;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Leonardo Fonseca Pontes · Perfil Profissional</title>
+    <meta
+      name="description"
+      content="Perfil profissional de Leonardo Fonseca Pontes, gerente de projetos especializado em transformação digital, educação e tecnologia."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+  </head>
+  <body>
+    <header class="topbar">
+      <div class="container topbar__inner">
+        <div class="brand">
+          <span class="brand__monogram" aria-hidden="true">LF</span>
+          <div>
+            <p class="brand__name">Leonardo Fonseca Pontes</p>
+            <p class="brand__role">Gerente de Projetos · Transformação Digital</p>
+          </div>
+        </div>
+        <nav class="menu" aria-label="Navegação principal">
+          <a href="#resumo">Sobre</a>
+          <a href="#experiencia">Experiência</a>
+          <a href="#competencias">Competências</a>
+          <a href="#certificacoes">Certificações</a>
+          <a href="#contato">Contato</a>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section id="inicio" class="hero">
+        <div class="container hero__inner">
+          <div class="hero__profile">
+            <span class="hero__badge">Disponível para liderar projetos estratégicos</span>
+            <h1>Construo experiências digitais que conectam educação e tecnologia.</h1>
+            <p>
+              Atuando como gerente de projetos, conduzo times multidisciplinares do discovery à entrega,
+              garantindo impacto real para clientes e parceiros do ecossistema educacional e tecnológico.
+            </p>
+            <div class="hero__actions">
+              <a class="button" href="mailto:leo.cun@gmail.com">Fale comigo</a>
+              <a
+                class="button button--ghost"
+                href="https://www.linkedin.com/in/leonardo-fonseca-pontes-465740103"
+                target="_blank"
+                rel="noopener noreferrer"
+                >LinkedIn</a
+              >
+            </div>
+            <div class="hero__stats" aria-label="Principais indicadores profissionais">
+              <article class="stat-card">
+                <p class="stat-card__value">10+</p>
+                <p class="stat-card__label">Projetos digitais orquestrados</p>
+              </article>
+              <article class="stat-card">
+                <p class="stat-card__value">6 anos</p>
+                <p class="stat-card__label">Liderando times de produto e projeto</p>
+              </article>
+              <article class="stat-card">
+                <p class="stat-card__value">3 pilares</p>
+                <p class="stat-card__label">Estratégia · Agilidade · Entrega de valor</p>
+              </article>
+            </div>
+          </div>
+
+          <aside class="hero__panel" aria-label="Informações rápidas">
+            <div class="hero__avatar" aria-hidden="true">
+              <span>LF</span>
+            </div>
+            <ul class="hero__details">
+              <li>
+                <span class="detail__label">Localização</span>
+                <span class="detail__value">Ribeirão Preto · São Paulo · Brasil</span>
+              </li>
+              <li>
+                <span class="detail__label">Contato</span>
+                <a class="detail__value" href="tel:+5516991091234">+55 16 99109-1234</a>
+              </li>
+              <li>
+                <span class="detail__label">E-mail</span>
+                <a class="detail__value" href="mailto:leo.cun@gmail.com">leo.cun@gmail.com</a>
+              </li>
+              <li>
+                <span class="detail__label">LinkedIn</span>
+                <a
+                  class="detail__value"
+                  href="https://www.linkedin.com/in/leonardo-fonseca-pontes-465740103"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >/in/leonardo-fonseca-pontes</a
+                >
+              </li>
+              <li>
+                <span class="detail__label">Idiomas</span>
+                <span class="detail__value">Português (Nativo) · Inglês (Nativo/Bilíngue)</span>
+              </li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section id="resumo" class="section">
+        <div class="container section__content">
+          <header class="section__header">
+            <span class="section__eyebrow">Sobre</span>
+            <h2>Resumo Executivo</h2>
+            <p>
+              Liderança focada em resolver desafios complexos com estratégia, tecnologia e colaboração.
+              Atuação end-to-end, da concepção de produtos digitais ao acompanhamento de resultados e evolução contínua.
+            </p>
+          </header>
+          <div class="feature-grid">
+            <article class="feature-card">
+              <h3>Motivações</h3>
+              <ul>
+                <li>Transformação digital aplicada a projetos de impacto.</li>
+                <li>Entrega de experiências memoráveis para clientes e usuários.</li>
+                <li>Conexão entre estratégia, produto e tecnologia.</li>
+                <li>Desenvolvimento de pessoas e cultura colaborativa.</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Foco estratégico</h3>
+              <ul>
+                <li>Gestão completa do ciclo de vida de projetos.</li>
+                <li>Planejamento orientado a resultados de negócio.</li>
+                <li>Liderança de squads multidisciplinares e remotos.</li>
+                <li>Governança, indicadores e melhoria contínua.</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Competências-chave</h3>
+              <ul>
+                <li>Tradução de necessidades em roadmaps de produto.</li>
+                <li>Facilitação de workshops de discovery e ideação.</li>
+                <li>Comunicação com stakeholders técnicos e executivos.</li>
+                <li>Estruturação de PMOs e cultura de feedback.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="experiencia" class="section section--accent">
+        <div class="container section__content">
+          <header class="section__header">
+            <span class="section__eyebrow">Trajetória</span>
+            <h2>Experiência Profissional</h2>
+            <p>
+              Projetos liderados em educação, tecnologia e serviços digitais, com foco em gerar valor mensurável para clientes e parceiros.
+            </p>
+          </header>
+          <div class="timeline">
+            <article class="timeline__item">
+              <header class="timeline__meta">
+                <p class="timeline__period">ago 2024 · atual</p>
+                <h3>Gerente de Projetos · Educacross</h3>
+                <p class="timeline__location">Ribeirão Preto, São Paulo</p>
+              </header>
+              <ul>
+                <li>Coordenação de portfólio estratégico do planejamento à entrega.</li>
+                <li>Integração entre stakeholders técnicos, pedagógicos e comerciais.</li>
+                <li>Estruturação de governança, indicadores e melhoria contínua.</li>
+                <li>Impulso à visibilidade da marca em iniciativas do setor educacional.</li>
+              </ul>
+            </article>
+
+            <article class="timeline__item">
+              <header class="timeline__meta">
+                <p class="timeline__period">mai 2022 · ago 2024</p>
+                <h3>Gerente de Projetos e Operações · Digi.ai</h3>
+                <p class="timeline__location">Ribeirão Preto, São Paulo</p>
+              </header>
+              <p class="timeline__summary">
+                Liderança de portfólio diversificado, estruturando escritórios de projetos e entregando soluções digitais sob medida.
+              </p>
+              <h4>Projetos em destaque</h4>
+              <ul>
+                <li>Integração entre plataformas e middleware conectando e-commerce a ERP legado.</li>
+                <li>Otimização de ERPs focados em transporte rodoviário de cargas.</li>
+                <li>Implantação de PMO com foco na absorção de demandas de clientes.</li>
+                <li>Construção de landing pages e jornadas digitais para diferentes segmentos.</li>
+              </ul>
+              <h4>Atuações-chave</h4>
+              <ul>
+                <li>Liderança de Product Owners e formação de squads multidisciplinares.</li>
+                <li>Gestão de cultura de feedback e participação em processos de contratação.</li>
+                <li>Promoção de comunicação interna e alinhamento de marca.</li>
+                <li>Aplicação de dinâmicas ágeis para medir clima, habilidades e requisitos.</li>
+              </ul>
+            </article>
+
+            <article class="timeline__item">
+              <header class="timeline__meta">
+                <p class="timeline__period">mar 2021 · mar 2024</p>
+                <h3>Product Owner · Digi.ai &amp; parceiros</h3>
+                <p class="timeline__location">Ribeirão Preto, São Paulo</p>
+              </header>
+              <h4>Projetos liderados</h4>
+              <ul>
+                <li>Integração de ERP legado e modernização tecnológica (MAG-IT Team).</li>
+                <li>Migração de software fiscal legado para .NET/React com práticas Scrum, Lean e SAFe (SMARAPD).</li>
+                <li>Integração de serviços Poupatempo/PRODESP para consultas tributárias municipais (SMARAPD).</li>
+                <li>Liderança de times de desenvolvimento em projetos fiscais e de arrecadação.</li>
+              </ul>
+            </article>
+
+            <article class="timeline__item">
+              <header class="timeline__meta">
+                <p class="timeline__period">jun 2019 · mar 2021</p>
+                <h3>Product Owner · Conexia Educação</h3>
+                <p class="timeline__location">Ribeirão Preto, São Paulo</p>
+              </header>
+              <h4>Produtos e soluções</h4>
+              <ul>
+                <li>APP Concept, AZ Applications e Conexia Books.</li>
+                <li>See &amp; Know, Soluções e GrowUp.</li>
+              </ul>
+              <h4>Principais entregas</h4>
+              <ul>
+                <li>Garantia de valor a cada sprint e gestão do backlog de produto.</li>
+                <li>Workshops de ideação com Design Thinking e discovery contínuo.</li>
+                <li>Medição de insights e evolução das habilidades do time.</li>
+                <li>Promoção de cultura de compartilhamento de conhecimento.</li>
+              </ul>
+            </article>
+
+            <article class="timeline__item">
+              <header class="timeline__meta">
+                <p class="timeline__period">ago 2018 · jun 2019</p>
+                <h3>Project Analyst · Conexia Educação</h3>
+                <p class="timeline__location">Ribeirão Preto, São Paulo</p>
+              </header>
+              <ul>
+                <li>Levantamento e documentação de requisitos com stakeholders.</li>
+                <li>Gestão de cronogramas, apresentações e demonstrações.</li>
+                <li>Otimização de processos internos e suporte a times terceirizados.</li>
+                <li>Atuação em recrutamento, formação de times e facilitação ágil.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="competencias" class="section">
+        <div class="container section__content">
+          <header class="section__header">
+            <span class="section__eyebrow">Habilidades</span>
+            <h2>Competências &amp; Ferramentas</h2>
+            <p>
+              Uma combinação de liderança, processos e visão de produto para conduzir transformações digitais sustentáveis.
+            </p>
+          </header>
+          <div class="competency-grid">
+            <article class="competency-card">
+              <h3>Liderança &amp; Pessoas</h3>
+              <ul>
+                <li>Formação e maturidade de squads seguindo o modelo de Tuckman.</li>
+                <li>Feedbacks, cultura colaborativa e clima organizacional.</li>
+                <li>Participação ativa em contratação e desenvolvimento de equipes.</li>
+              </ul>
+            </article>
+            <article class="competency-card">
+              <h3>Agilidade &amp; Processos</h3>
+              <ul>
+                <li>Scrum, Lean, SAFe e práticas de Product Discovery.</li>
+                <li>Dinâmicas de mapeamento de habilidades, Squad Health Check e Skill Map.</li>
+                <li>Governança, indicadores e melhoria contínua em PMOs.</li>
+              </ul>
+            </article>
+            <article class="competency-card">
+              <h3>Entrega de Valor</h3>
+              <ul>
+                <li>Roadmaps de produto orientados a objetivos de negócio.</li>
+                <li>Workshops de Design Thinking e experiência do usuário.</li>
+                <li>Comunicação com stakeholders técnicos e executivos.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="certificacoes" class="section section--accent">
+        <div class="container section__content">
+          <header class="section__header">
+            <span class="section__eyebrow">Atualização contínua</span>
+            <h2>Certificações &amp; Cursos</h2>
+            <p>Capacitações que fortalecem a atuação em gestão de projetos e produtos digitais.</p>
+          </header>
+          <div class="certification-list">
+            <article class="certification-card">
+              <h3>JavaScript: manipulando o DOM</h3>
+              <p>Alura · 2023</p>
+            </article>
+            <article class="certification-card">
+              <h3>HTML e CSS: praticando HTML/CSS</h3>
+              <p>Alura · 2023</p>
+            </article>
+            <article class="certification-card">
+              <h3>HTML e CSS: responsividade e publicação de projetos</h3>
+              <p>Alura · 2023</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="contato" class="section section--highlight">
+        <div class="container callout">
+          <div>
+            <h2>Vamos conversar?</h2>
+            <p>
+              Busco conectar estratégia e execução para elevar o impacto de produtos digitais.
+              Vamos construir o próximo projeto juntos.
+            </p>
+          </div>
+          <div class="callout__actions">
+            <a class="button" href="mailto:leo.cun@gmail.com">Enviar e-mail</a>
+            <a
+              class="button button--ghost"
+              href="https://www.linkedin.com/in/leonardo-fonseca-pontes-465740103"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Conectar no LinkedIn</a
+            >
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="container footer__content">
+        <p>&copy; <span id="year"></span> Leonardo Fonseca Pontes. Todos os direitos reservados.</p>
+      </div>
+    </footer>
+
+    <script>
+      const yearElement = document.getElementById('year');
+      if (yearElement) {
+        yearElement.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- redesign the portfolio page with a dark, premium hero inspired layout featuring quick info panel and navigation
- reorganize professional summary, experience, competencies, and certifications into accentuated card and timeline blocks
- refresh styling tokens with new color palette, gradients, and responsive behaviors for the updated structure

## Testing
- python -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68d698bce220832ab119fdac79d2aad0