### PR TITLE
Improve interactive states for portfolio cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -198,6 +198,15 @@ li + li {
   box-shadow: var(--shadow-soft);
 }
 
+.stat-card,
+.feature-card,
+.competency-card,
+.certification-card,
+.timeline__item {
+  transition: transform 220ms ease, box-shadow 220ms ease,
+    border-color 220ms ease, background 220ms ease;
+}
+
 .stat-card__value {
   margin: 0;
   font-size: 1.8rem;
@@ -315,6 +324,20 @@ li + li {
   box-shadow: var(--shadow-soft);
 }
 
+.stat-card:hover,
+.stat-card:focus-within,
+.feature-card:hover,
+.feature-card:focus-within,
+.competency-card:hover,
+.competency-card:focus-within,
+.certification-card:hover,
+.certification-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 28px 55px rgba(9, 12, 28, 0.55),
+    0 0 0 1px rgba(246, 183, 60, 0.45);
+  border-color: var(--color-accent);
+}
+
 .timeline {
   position: relative;
   display: grid;
@@ -330,8 +353,16 @@ li + li {
 }
 
 .timeline__item {
-  padding: 0 0 0 4.5rem;
   position: relative;
+  padding: 1.2rem 1.75rem 1.35rem 4.5rem;
+  border-radius: var(--radius-md);
+  background: linear-gradient(
+    135deg,
+    rgba(246, 183, 60, 0.07),
+    rgba(91, 128, 255, 0.06)
+  );
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: var(--shadow-soft);
 }
 
 .timeline__item::before {
@@ -345,6 +376,28 @@ li + li {
   border: 3px solid rgba(5, 8, 22, 0.85);
   background: linear-gradient(135deg, rgba(246, 183, 60, 0.9), rgba(91, 128, 255, 0.7));
   box-shadow: 0 0 0 6px rgba(246, 183, 60, 0.1);
+  transition: transform 220ms ease, box-shadow 220ms ease,
+    background 220ms ease;
+}
+
+.timeline__item:hover,
+.timeline__item:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 30px 60px rgba(9, 12, 28, 0.6),
+    0 0 0 1px rgba(246, 183, 60, 0.6);
+  border-color: rgba(246, 183, 60, 0.65);
+  background: linear-gradient(
+    135deg,
+    rgba(246, 183, 60, 0.12),
+    rgba(91, 128, 255, 0.12)
+  );
+}
+
+.timeline__item:hover::before,
+.timeline__item:focus-within::before {
+  box-shadow: 0 0 0 10px rgba(246, 183, 60, 0.22);
+  background: linear-gradient(135deg, rgba(246, 183, 60, 1), rgba(91, 128, 255, 0.9));
+  transform: scale(1.05);
 }
 
 .timeline__meta h3 {
@@ -405,6 +458,32 @@ li + li {
   padding: 1.7rem 1.9rem;
   border: 1px solid rgba(255, 255, 255, 0.07);
   box-shadow: var(--shadow-soft);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stat-card,
+  .feature-card,
+  .competency-card,
+  .certification-card,
+  .timeline__item,
+  .timeline__item::before {
+    transition: none;
+  }
+
+  .stat-card:hover,
+  .stat-card:focus-within,
+  .feature-card:hover,
+  .feature-card:focus-within,
+  .competency-card:hover,
+  .competency-card:focus-within,
+  .certification-card:hover,
+  .certification-card:focus-within,
+  .timeline__item:hover,
+  .timeline__item:focus-within,
+  .timeline__item:hover::before,
+  .timeline__item:focus-within::before {
+    transform: none;
+  }
 }
 
 .callout {


### PR DESCRIPTION
## Summary
- add shared transition styles for stat, feature, competency, certification, and timeline cards
- enhance hover and focus feedback with accent shadows and gentle transforms, including the timeline badge
- respect prefers-reduced-motion to keep interactions accessible

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6a5088214832abd331b8939b4a5d4