### PR TITLE
Adjust hero layout to align profile and panel

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -158,6 +158,17 @@ li + li {
   align-items: start;
 }
 
+@media (min-width: 960px) {
+  .hero__inner {
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+    align-items: stretch;
+  }
+
+  .hero__panel {
+    align-self: stretch;
+  }
+}
+
 .hero__profile h1 {
   font-size: clamp(2.2rem, 3.9vw, 3.4rem);
   margin-bottom: 1.25rem;


### PR DESCRIPTION
## Summary
- introduce a responsive two-column grid for the hero inner container on large screens
- ensure the hero panel stretches to match the profile column height for balanced alignment

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6d18a39f8832aa45fdcbef26dfcd9