### PR TITLE
Refine carousel layout and pagination

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -469,8 +469,11 @@ li + li {
   padding: 1.7rem 1.9rem;
   border: 1px solid rgba(255, 255, 255, 0.07);
   box-shadow: var(--shadow-soft);
-  flex: 0 0 var(--carousel-card-width, calc((100% - 2 * var(--carousel-gap, 1.5rem)) / 3));
-  scroll-snap-align: center;
+  flex: 0 0 var(
+    --carousel-card-width,
+    calc((100% - 2 * var(--carousel-gap, 1.5rem)) / 3)
+  );
+  scroll-snap-align: start;
   position: relative;
   overflow: hidden;
   transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease,
@@ -511,23 +514,32 @@ li + li {
 
 .carousel {
   position: relative;
-  display: flex;
-  align-items: center;
-  gap: 1rem;
+  --carousel-gap: 1.5rem;
+  --carousel-visible: 3;
+  --carousel-card-max-width: 320px;
+  --carousel-viewport-width: min(
+    100%,
+    calc(
+      var(--carousel-visible, 3) * var(--carousel-card-max-width, 320px) +
+        (var(--carousel-visible, 3) - 1) * var(--carousel-gap, 1.5rem)
+    )
+  );
 }
 
 .carousel__viewport {
-  --carousel-gap: 1.5rem;
-  --carousel-card-width: calc((100% - 2 * var(--carousel-gap, 1.5rem)) / 3);
+  --carousel-card-width: calc(
+    (100% - (var(--carousel-visible, 3) - 1) * var(--carousel-gap, 1.5rem)) /
+      var(--carousel-visible, 3)
+  );
   display: flex;
   align-items: stretch;
   gap: var(--carousel-gap, 1.5rem);
   overflow-x: auto;
   scroll-snap-type: x mandatory;
   scroll-snap-stop: always;
-  scroll-padding-inline: calc((100% - var(--carousel-card-width, calc((100% - 2 * var(--carousel-gap, 1.5rem)) / 3))) / 2);
   padding: 0.5rem 0 0.75rem;
-  width: 100%;
+  margin: 0 auto;
+  width: var(--carousel-viewport-width, 100%);
   scrollbar-width: thin;
   scrollbar-color: rgba(246, 183, 60, 0.5) rgba(255, 255, 255, 0.05);
 }
@@ -557,12 +569,16 @@ li + li {
   background: rgba(12, 16, 32, 0.75);
   color: var(--color-text);
   cursor: pointer;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
   transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+  z-index: 2;
 }
 
 .carousel__control:hover,
 .carousel__control:focus {
-  transform: translateY(-2px);
+  transform: translateY(calc(-50% - 2px));
   border-color: rgba(246, 183, 60, 0.6);
   background: rgba(12, 16, 32, 0.95);
 }
@@ -570,6 +586,14 @@ li + li {
 .carousel__control[disabled] {
   opacity: 0.35;
   cursor: not-allowed;
+}
+
+.carousel__control--prev {
+  left: calc((100% - var(--carousel-viewport-width, 100%)) / 2 + 0.5rem);
+}
+
+.carousel__control--next {
+  right: calc((100% - var(--carousel-viewport-width, 100%)) / 2 + 0.5rem);
 }
 
 .carousel__hint {
@@ -679,19 +703,16 @@ li + li {
 }
 
 @media (max-width: 1080px) {
-  .carousel__viewport {
-    --carousel-card-width: calc((100% - var(--carousel-gap, 1.5rem)) / 2);
+  .carousel {
+    --carousel-visible: 2;
   }
 }
 
 @media (max-width: 720px) {
   .carousel {
-    gap: 0.5rem;
-  }
-  
-  .carousel__viewport {
     --carousel-gap: 1rem;
-    --carousel-card-width: min(320px, 86vw);
+    --carousel-visible: 1;
+    --carousel-card-max-width: min(320px, 86vw);
   }
 
   .carousel__control {

--- a/index.html
+++ b/index.html
@@ -707,68 +707,80 @@
           return;
         }
 
-        const clampIndex = (index) => Math.max(0, Math.min(index, cards.length - 1));
-        const applyActiveState = (index) => {
+        const getCardsPerView = () => {
+          const styles = window.getComputedStyle(viewport);
+          const visible = Number.parseInt(styles.getPropertyValue('--carousel-visible'), 10);
+          if (!Number.isNaN(visible) && visible > 0) {
+            return visible;
+          }
+
+          const firstCardWidth = cards[0]?.getBoundingClientRect().width || viewport.clientWidth;
+          if (!firstCardWidth) {
+            return 1;
+          }
+
+          return Math.max(1, Math.round(viewport.clientWidth / firstCardWidth));
+        };
+
+        const clampIndex = (index) => {
+          const perView = getCardsPerView();
+          const maxIndex = Math.max(0, cards.length - perView);
+          return Math.max(0, Math.min(index, maxIndex));
+        };
+
+        let activeIndex = 0;
+
+        const applyActiveState = () => {
+          const perView = getCardsPerView();
           cards.forEach((card, cardIndex) => {
-            card.classList.toggle('is-active', cardIndex === index);
+            const isActive = cardIndex >= activeIndex && cardIndex < activeIndex + perView;
+            card.classList.toggle('is-active', isActive);
           });
         };
 
         const scrollToCard = (index, smooth = true) => {
-          const targetCard = cards[clampIndex(index)];
+          const targetIndex = clampIndex(index);
+          const targetCard = cards[targetIndex];
           if (!targetCard) {
             return;
           }
 
-          const availableScroll = viewport.scrollWidth - viewport.clientWidth;
-          const offset = targetCard.offsetLeft - (viewport.clientWidth - targetCard.offsetWidth) / 2;
-          const targetScroll = Math.min(Math.max(offset, 0), availableScroll);
-
           viewport.scrollTo({
-            left: targetScroll,
+            left: targetCard.offsetLeft,
             behavior: smooth ? 'smooth' : 'auto',
           });
         };
 
-        let activeIndex = clampIndex(cards.length > 1 ? 1 : 0);
-
         const updateControls = () => {
+          const perView = getCardsPerView();
+          const maxIndex = Math.max(0, cards.length - perView);
           if (prevButton) {
             prevButton.disabled = activeIndex <= 0;
           }
           if (nextButton) {
-            nextButton.disabled = activeIndex >= cards.length - 1;
+            nextButton.disabled = activeIndex >= maxIndex;
           }
         };
 
         const goToCard = (index, { smooth = true } = {}) => {
           const nextIndex = clampIndex(index);
-          if (nextIndex === activeIndex && smooth) {
-            scrollToCard(nextIndex, smooth);
-            return;
-          }
-
           activeIndex = nextIndex;
-          applyActiveState(activeIndex);
+          applyActiveState();
           updateControls();
           scrollToCard(activeIndex, smooth);
         };
 
-        const findClosestIndex = () => {
-          const viewportCenter = viewport.scrollLeft + viewport.clientWidth / 2;
-          let closest = activeIndex;
-          let minDistance = Number.POSITIVE_INFINITY;
+        const findFirstVisibleIndex = () => {
+          const scrollLeft = viewport.scrollLeft;
+          let firstVisible = 0;
 
           cards.forEach((card, index) => {
-            const cardCenter = card.offsetLeft + card.offsetWidth / 2;
-            const distance = Math.abs(viewportCenter - cardCenter);
-            if (distance < minDistance) {
-              minDistance = distance;
-              closest = index;
+            if (card.offsetLeft <= scrollLeft + 1) {
+              firstVisible = index;
             }
           });
 
-          return closest;
+          return clampIndex(firstVisible);
         };
 
         let ticking = false;
@@ -779,25 +791,23 @@
 
           ticking = true;
           window.requestAnimationFrame(() => {
-            const closestIndex = findClosestIndex();
+            const closestIndex = findFirstVisibleIndex();
             if (closestIndex !== activeIndex) {
               activeIndex = closestIndex;
-              applyActiveState(activeIndex);
+              applyActiveState();
               updateControls();
             }
             ticking = false;
           });
         };
 
-        prevButton?.addEventListener('click', () => goToCard(activeIndex - 1));
-        nextButton?.addEventListener('click', () => goToCard(activeIndex + 1));
+        prevButton?.addEventListener('click', () => goToCard(activeIndex - getCardsPerView()));
+        nextButton?.addEventListener('click', () => goToCard(activeIndex + getCardsPerView()));
 
         viewport.addEventListener('scroll', handleScroll, { passive: true });
         window.addEventListener('resize', () => goToCard(activeIndex, { smooth: false }));
 
-        applyActiveState(activeIndex);
-        updateControls();
-        scrollToCard(activeIndex, false);
+        goToCard(0, { smooth: false });
 
       });
     </script>


### PR DESCRIPTION
## Summary
- center the carousel viewport while keeping absolute navigation controls and limiting wide layouts to three visible cards
- adjust certification card snap behavior and responsive spacing through shared carousel CSS variables
- paginate the carousel by page size in JavaScript, aligning pages to the first visible card and activating only in-view items

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d6d3c2a220832a909a19ecd3077ded