### PR TITLE
Fix carousel visible detection and initial activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -707,10 +707,28 @@
           return;
         }
 
+        const readVisibleSetting = (element) => {
+          if (!element) {
+            return undefined;
+          }
+
+          const styles = window.getComputedStyle(element);
+          const rawValue = styles.getPropertyValue('--carousel-visible').trim();
+          if (!rawValue) {
+            return undefined;
+          }
+
+          const parsed = Number.parseInt(rawValue, 10);
+          if (!Number.isNaN(parsed) && parsed > 0) {
+            return parsed;
+          }
+
+          return undefined;
+        };
+
         const getCardsPerView = () => {
-          const styles = window.getComputedStyle(viewport);
-          const visible = Number.parseInt(styles.getPropertyValue('--carousel-visible'), 10);
-          if (!Number.isNaN(visible) && visible > 0) {
+          const visible = readVisibleSetting(carousel) ?? readVisibleSetting(viewport);
+          if (typeof visible === 'number') {
             return visible;
           }
 
@@ -807,7 +825,9 @@
         viewport.addEventListener('scroll', handleScroll, { passive: true });
         window.addEventListener('resize', () => goToCard(activeIndex, { smooth: false }));
 
-        goToCard(0, { smooth: false });
+        window.requestAnimationFrame(() => {
+          goToCard(0, { smooth: false });
+        });
 
       });
     </script>


### PR DESCRIPTION
## Summary
- read the `--carousel-visible` custom property from the carousel element with a viewport fallback before width-based calculations
- defer the initial carousel activation until the next animation frame so layout-dependent measurements use the final CSS values

## Testing
- Manual Playwright verification of the “Certificações & Cursos” carousel

------
https://chatgpt.com/codex/tasks/task_e_68d6db8c1f08832a8f3ffac460dcaec0