### PR TITLE
Ensure carousel initialization waits for load

### DIFF
--- a/index.html
+++ b/index.html
@@ -707,10 +707,28 @@
           return;
         }
 
+        const readVisibleSetting = (element) => {
+          if (!element) {
+            return undefined;
+          }
+
+          const styles = window.getComputedStyle(element);
+          const rawValue = styles.getPropertyValue('--carousel-visible').trim();
+          if (!rawValue) {
+            return undefined;
+          }
+
+          const parsed = Number.parseInt(rawValue, 10);
+          if (!Number.isNaN(parsed) && parsed > 0) {
+            return parsed;
+          }
+
+          return undefined;
+        };
+
         const getCardsPerView = () => {
-          const styles = window.getComputedStyle(viewport);
-          const visible = Number.parseInt(styles.getPropertyValue('--carousel-visible'), 10);
-          if (!Number.isNaN(visible) && visible > 0) {
+          const visible = readVisibleSetting(carousel) ?? readVisibleSetting(viewport);
+          if (typeof visible === 'number') {
             return visible;
           }
 
@@ -807,7 +825,23 @@
         viewport.addEventListener('scroll', handleScroll, { passive: true });
         window.addEventListener('resize', () => goToCard(activeIndex, { smooth: false }));
 
-        goToCard(0, { smooth: false });
+        const initializeCarousel = () => {
+          window.requestAnimationFrame(() => {
+            goToCard(0, { smooth: false });
+          });
+        };
+
+        if (document.readyState === 'complete') {
+          initializeCarousel();
+        } else {
+          window.addEventListener(
+            'load',
+            () => {
+              initializeCarousel();
+            },
+            { once: true }
+          );
+        }
 
       });
     </script>


### PR DESCRIPTION
## Summary
- wrap the initial carousel activation in a helper that defers execution to the next animation frame
- trigger the initialization only after the window load event (or immediately if already loaded) so computed CSS custom properties are applied correctly

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d6db8c1f08832a8f3ffac460dcaec0