### PR TITLE
Estiliza callout de contato e botões reutilizáveis

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -47,6 +47,52 @@ a:focus {
   text-decoration: underline;
 }
 
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: var(--color-accent);
+  color: rgba(5, 8, 22, 0.92);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  transition: transform 180ms ease, box-shadow 180ms ease,
+    background-color 180ms ease, color 180ms ease;
+}
+
+.button:hover,
+.button:focus-visible {
+  background: rgba(246, 183, 60, 0.92);
+  color: rgba(5, 8, 22, 0.95);
+  box-shadow: 0 16px 38px rgba(246, 183, 60, 0.24);
+  transform: translateY(-1px);
+  text-decoration: none;
+}
+
+.button:focus-visible {
+  outline: 3px solid rgba(246, 183, 60, 0.65);
+  outline-offset: 2px;
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--color-accent);
+  border-color: rgba(246, 183, 60, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(246, 183, 60, 0.25);
+}
+
+.button--ghost:hover,
+.button--ghost:focus-visible {
+  background: rgba(246, 183, 60, 0.18);
+  color: var(--color-text);
+  box-shadow: inset 0 0 0 1px rgba(246, 183, 60, 0.4),
+    0 12px 30px rgba(246, 183, 60, 0.12);
+}
+
 p {
   margin: 0 0 1rem;
   color: var(--color-text-muted);
@@ -297,6 +343,36 @@ li + li {
 .section {
   padding: 5rem 0;
   position: relative;
+}
+
+.callout {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.75rem 2.5rem;
+  padding: 3rem 3.25rem;
+  background: linear-gradient(135deg, rgba(21, 26, 46, 0.92), rgba(12, 16, 32, 0.88));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow-panel);
+  color: var(--color-text);
+}
+
+.callout h2 {
+  margin-bottom: 0.75rem;
+}
+
+.callout__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem 1rem;
+}
+
+.callout__actions .button {
+  min-width: 180px;
 }
 
 .section--accent {
@@ -699,6 +775,38 @@ li + li {
 
   .testimonial-card__relationship {
     align-self: flex-start;
+  }
+}
+
+@media (max-width: 960px) {
+  .callout {
+    flex-direction: column;
+    align-items: flex-start;
+    text-align: left;
+    padding: 2.5rem 2.25rem;
+  }
+
+  .callout__actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .callout {
+    gap: 1.5rem;
+  }
+
+  .callout__actions {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    gap: 0.75rem;
+  }
+
+  .callout__actions .button {
+    min-width: 0;
+    width: 100%;
+    justify-content: center;
   }
 }
 


### PR DESCRIPTION
## Summary
- adiciona estilos reutilizáveis para botões primários e ghost com estados de foco e hover acessíveis
- aplica layout aprimorado ao callout de contato, alinhando texto e ações com flexbox
- ajusta responsividade do bloco de ações para manter contraste e legibilidade em telas menores

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6dff0329c832a906d507cce7dc986