### PR TITLE
Replace certifications carousel with responsive grid

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -539,23 +539,22 @@ li + li {
   box-shadow: var(--shadow-soft);
 }
 
+.certifications-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.75rem;
+}
+
 .certification-card {
   background: var(--color-surface-alt);
   border-radius: var(--radius-md);
   padding: 1.7rem 1.9rem;
   border: 1px solid rgba(255, 255, 255, 0.07);
   box-shadow: var(--shadow-soft);
-  flex: 0 0 var(
-    --carousel-card-width,
-    calc((100% - 2 * var(--carousel-gap, 1.5rem)) / 3)
-  );
-  scroll-snap-align: start;
   position: relative;
   overflow: hidden;
   transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease,
-    background 0.35s ease, opacity 0.35s ease;
-  opacity: 0.7;
-  transform: scale(0.94);
+    background 0.35s ease;
 }
 
 .certification-card h3 {
@@ -579,103 +578,10 @@ li + li {
   text-transform: uppercase;
 }
 
-.certification-card--focus,
-.certification-card.is-active {
+.certification-card--focus {
   border: 1px solid rgba(246, 183, 60, 0.55);
   background: linear-gradient(150deg, rgba(246, 183, 60, 0.16), rgba(91, 128, 255, 0.1));
   box-shadow: 0 32px 60px rgba(10, 13, 35, 0.7);
-  opacity: 1;
-  transform: scale(1);
-}
-
-.carousel {
-  position: relative;
-  --carousel-gap: 1.5rem;
-  --carousel-visible: 3;
-  --carousel-card-max-width: 320px;
-  --carousel-viewport-width: min(
-    100%,
-    calc(
-      var(--carousel-visible, 3) * var(--carousel-card-max-width, 320px) +
-        (var(--carousel-visible, 3) - 1) * var(--carousel-gap, 1.5rem)
-    )
-  );
-}
-
-.carousel__viewport {
-  --carousel-card-width: calc(
-    (100% - (var(--carousel-visible, 3) - 1) * var(--carousel-gap, 1.5rem)) /
-      var(--carousel-visible, 3)
-  );
-  display: flex;
-  align-items: stretch;
-  gap: var(--carousel-gap, 1.5rem);
-  overflow-x: auto;
-  scroll-snap-type: x mandatory;
-  scroll-snap-stop: always;
-  padding: 0.5rem 0 0.75rem;
-  margin: 0;
-  width: 100%;
-  scrollbar-width: thin;
-  scrollbar-color: rgba(246, 183, 60, 0.5) rgba(255, 255, 255, 0.05);
-}
-
-.carousel__viewport::-webkit-scrollbar {
-  height: 8px;
-}
-
-.carousel__viewport::-webkit-scrollbar-track {
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 999px;
-}
-
-.carousel__viewport::-webkit-scrollbar-thumb {
-  background: rgba(246, 183, 60, 0.45);
-  border-radius: 999px;
-}
-
-.carousel__control {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 42px;
-  height: 42px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(12, 16, 32, 0.75);
-  color: var(--color-text);
-  cursor: pointer;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
-  z-index: 2;
-}
-
-.carousel__control:hover,
-.carousel__control:focus {
-  transform: translateY(calc(-50% - 2px));
-  border-color: rgba(246, 183, 60, 0.6);
-  background: rgba(12, 16, 32, 0.95);
-}
-
-.carousel__control[disabled] {
-  opacity: 0.35;
-  cursor: not-allowed;
-}
-
-.carousel__control--prev {
-  left: 0.5rem;
-}
-
-.carousel__control--next {
-  right: 0.5rem;
-}
-
-.carousel__hint {
-  margin-top: 1rem;
-  font-size: 0.85rem;
-  color: rgba(229, 233, 255, 0.6);
 }
 
 .testimonial-grid {
@@ -811,19 +717,13 @@ li + li {
 }
 
 @media (max-width: 1080px) {
-  .carousel {
-    --carousel-visible: 2;
+  .certifications-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 @media (max-width: 720px) {
-  .carousel {
-    --carousel-gap: 1rem;
-    --carousel-visible: 1;
-    --carousel-card-max-width: min(320px, 86vw);
-  }
-
-  .carousel__control {
-    display: none;
+  .certifications-grid {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
   }
 }

--- a/index.html
+++ b/index.html
@@ -401,87 +401,78 @@
             <h2>Certificações &amp; Cursos</h2>
             <p>Capacitações que fortalecem a atuação em gestão de projetos e produtos digitais.</p>
           </header>
-          <div class="carousel" data-carousel>
-            <button class="carousel__control carousel__control--prev" type="button" data-carousel-prev aria-label="Ver certificados anteriores">
-              <span aria-hidden="true">&#10094;</span>
-            </button>
-            <div class="carousel__viewport" data-carousel-viewport>
-              <article class="certification-card">
-                <h3>Transitioning from Waterfall to Agile Project Management</h3>
-                <p>LinkedIn Learning · Emitido jan 2020</p>
-                <span class="certification-card__tag">Agile Leadership</span>
-              </article>
-              <article class="certification-card">
-                <h3>Scrum: Advanced</h3>
-                <p>LinkedIn Learning · Emitido jan 2020</p>
-                <span class="certification-card__tag">Scrum Mastery</span>
-              </article>
-              <article class="certification-card">
-                <h3>OKR Bootcamp</h3>
-                <p>Sympla · Emitido jul 2019</p>
-                <span class="certification-card__tag">Governança &amp; Métricas</span>
-              </article>
-              <article class="certification-card">
-                <h3>Kanban Foundation Certificate</h3>
-                <p>Certiprof · Emitido set 2020</p>
-                <span class="certification-card__tag">Fluxo Contínuo</span>
-              </article>
-              <article class="certification-card">
-                <h3>JavaScript: explorando a manipulação de elementos e da localStorage</h3>
-                <p>Alura · Emitido fev 2024</p>
-                <span class="certification-card__tag">Front-end</span>
-              </article>
-              <article class="certification-card">
-                <h3>JavaScript na Web: armazenando dados no navegador</h3>
-                <p>Alura · Emitido fev 2024</p>
-                <span class="certification-card__tag">Front-end</span>
-              </article>
-              <article class="certification-card">
-                <h3>JavaScript para Web: Crie páginas dinâmicas</h3>
-                <p>Alura · Emitido fev 2024</p>
-                <span class="certification-card__tag">Front-end</span>
-              </article>
-              <article class="certification-card">
-                <h3>JavaScript: consumindo e tratando dados de uma API</h3>
-                <p>Alura · Emitido fev 2024</p>
-                <span class="certification-card__tag">Integrações</span>
-              </article>
-              <article class="certification-card">
-                <h3>JavaScript: manipulando o DOM</h3>
-                <p>Alura · Emitido fev 2024</p>
-                <span class="certification-card__tag">Interatividade</span>
-              </article>
-              <article class="certification-card">
-                <h3>JavaScript: validações e reconhecimento de voz</h3>
-                <p>Alura · Emitido fev 2024</p>
-                <span class="certification-card__tag">Experiência do Usuário</span>
-              </article>
-              <article class="certification-card">
-                <h3>HTML e CSS: ambientes de desenvolvimento, estrutura e tags</h3>
-                <p>Alura · Emitido jan 2024</p>
-                <span class="certification-card__tag">Fundamentos Web</span>
-              </article>
-              <article class="certification-card">
-                <h3>HTML e CSS: cabeçalho, footer e variáveis CSS</h3>
-                <p>Alura · Emitido jan 2024</p>
-                <span class="certification-card__tag">UI Engineering</span>
-              </article>
-              <article class="certification-card">
-                <h3>HTML e CSS: classes, posicionamento e Flexbox</h3>
-                <p>Alura · Emitido jan 2024</p>
-                <span class="certification-card__tag">Layout</span>
-              </article>
-              <article class="certification-card">
-                <h3>HTML e CSS: praticando HTML/CSS</h3>
-                <p>Alura · Emitido jan 2024</p>
-                <span class="certification-card__tag">Boas Práticas</span>
-              </article>
-            </div>
-            <button class="carousel__control carousel__control--next" type="button" data-carousel-next aria-label="Ver próximos certificados">
-              <span aria-hidden="true">&#10095;</span>
-            </button>
+          <div class="certifications-grid">
+            <article class="certification-card">
+              <h3>Transitioning from Waterfall to Agile Project Management</h3>
+              <p>LinkedIn Learning · Emitido jan 2020</p>
+              <span class="certification-card__tag">Agile Leadership</span>
+            </article>
+            <article class="certification-card">
+              <h3>Scrum: Advanced</h3>
+              <p>LinkedIn Learning · Emitido jan 2020</p>
+              <span class="certification-card__tag">Scrum Mastery</span>
+            </article>
+            <article class="certification-card">
+              <h3>OKR Bootcamp</h3>
+              <p>Sympla · Emitido jul 2019</p>
+              <span class="certification-card__tag">Governança &amp; Métricas</span>
+            </article>
+            <article class="certification-card">
+              <h3>Kanban Foundation Certificate</h3>
+              <p>Certiprof · Emitido set 2020</p>
+              <span class="certification-card__tag">Fluxo Contínuo</span>
+            </article>
+            <article class="certification-card">
+              <h3>JavaScript: explorando a manipulação de elementos e da localStorage</h3>
+              <p>Alura · Emitido fev 2024</p>
+              <span class="certification-card__tag">Front-end</span>
+            </article>
+            <article class="certification-card">
+              <h3>JavaScript na Web: armazenando dados no navegador</h3>
+              <p>Alura · Emitido fev 2024</p>
+              <span class="certification-card__tag">Front-end</span>
+            </article>
+            <article class="certification-card">
+              <h3>JavaScript para Web: Crie páginas dinâmicas</h3>
+              <p>Alura · Emitido fev 2024</p>
+              <span class="certification-card__tag">Front-end</span>
+            </article>
+            <article class="certification-card">
+              <h3>JavaScript: consumindo e tratando dados de uma API</h3>
+              <p>Alura · Emitido fev 2024</p>
+              <span class="certification-card__tag">Integrações</span>
+            </article>
+            <article class="certification-card">
+              <h3>JavaScript: manipulando o DOM</h3>
+              <p>Alura · Emitido fev 2024</p>
+              <span class="certification-card__tag">Interatividade</span>
+            </article>
+            <article class="certification-card">
+              <h3>JavaScript: validações e reconhecimento de voz</h3>
+              <p>Alura · Emitido fev 2024</p>
+              <span class="certification-card__tag">Experiência do Usuário</span>
+            </article>
+            <article class="certification-card">
+              <h3>HTML e CSS: ambientes de desenvolvimento, estrutura e tags</h3>
+              <p>Alura · Emitido jan 2024</p>
+              <span class="certification-card__tag">Fundamentos Web</span>
+            </article>
+            <article class="certification-card">
+              <h3>HTML e CSS: cabeçalho, footer e variáveis CSS</h3>
+              <p>Alura · Emitido jan 2024</p>
+              <span class="certification-card__tag">UI Engineering</span>
+            </article>
+            <article class="certification-card">
+              <h3>HTML e CSS: classes, posicionamento e Flexbox</h3>
+              <p>Alura · Emitido jan 2024</p>
+              <span class="certification-card__tag">Layout</span>
+            </article>
+            <article class="certification-card">
+              <h3>HTML e CSS: praticando HTML/CSS</h3>
+              <p>Alura · Emitido jan 2024</p>
+              <span class="certification-card__tag">Boas Práticas</span>
+            </article>
           </div>
-          <p class="carousel__hint">Arraste horizontalmente ou utilize as setas para navegar pelo carrossel.</p>
         </div>
       </section>
 
@@ -643,7 +634,6 @@
               </footer>
             </article>
           </div>
-          <p class="carousel__hint">Arraste horizontalmente ou utilize as setas para navegar pelo carrossel.</p>
         </div>
       </section>
 
@@ -696,140 +686,6 @@
       window.addEventListener('load', updateTopbarOffset);
       window.addEventListener('resize', updateTopbarOffset);
 
-      const carousels = document.querySelectorAll('[data-carousel]');
-      carousels.forEach((carousel) => {
-        const viewport = carousel.querySelector('[data-carousel-viewport]');
-        const prevButton = carousel.querySelector('[data-carousel-prev]');
-        const nextButton = carousel.querySelector('[data-carousel-next]');
-        const cards = viewport ? Array.from(viewport.querySelectorAll('.certification-card')) : [];
-
-        if (!viewport || !cards.length) {
-          return;
-        }
-
-        const readVisibleSetting = (element) => {
-          if (!element) {
-            return undefined;
-          }
-
-          const styles = window.getComputedStyle(element);
-          const rawValue = styles.getPropertyValue('--carousel-visible').trim();
-          if (!rawValue) {
-            return undefined;
-          }
-
-          const parsed = Number.parseInt(rawValue, 10);
-          if (!Number.isNaN(parsed) && parsed > 0) {
-            return parsed;
-          }
-
-          return undefined;
-        };
-
-        const getCardsPerView = () => {
-          const visible = readVisibleSetting(carousel) ?? readVisibleSetting(viewport);
-          if (typeof visible === 'number') {
-            return visible;
-          }
-
-          const firstCardWidth = cards[0]?.getBoundingClientRect().width || viewport.clientWidth;
-          if (!firstCardWidth) {
-            return 1;
-          }
-
-          return Math.max(1, Math.round(viewport.clientWidth / firstCardWidth));
-        };
-
-        const clampIndex = (index) => {
-          const perView = getCardsPerView();
-          const maxIndex = Math.max(0, cards.length - perView);
-          return Math.max(0, Math.min(index, maxIndex));
-        };
-
-        let activeIndex = 0;
-
-        const applyActiveState = () => {
-          const perView = getCardsPerView();
-          cards.forEach((card, cardIndex) => {
-            const isActive = cardIndex >= activeIndex && cardIndex < activeIndex + perView;
-            card.classList.toggle('is-active', isActive);
-          });
-        };
-
-        const scrollToCard = (index, smooth = true) => {
-          const targetIndex = clampIndex(index);
-          const targetCard = cards[targetIndex];
-          if (!targetCard) {
-            return;
-          }
-
-          viewport.scrollTo({
-            left: targetCard.offsetLeft,
-            behavior: smooth ? 'smooth' : 'auto',
-          });
-        };
-
-        const updateControls = () => {
-          const perView = getCardsPerView();
-          const maxIndex = Math.max(0, cards.length - perView);
-          if (prevButton) {
-            prevButton.disabled = activeIndex <= 0;
-          }
-          if (nextButton) {
-            nextButton.disabled = activeIndex >= maxIndex;
-          }
-        };
-
-        const goToCard = (index, { smooth = true } = {}) => {
-          const nextIndex = clampIndex(index);
-          activeIndex = nextIndex;
-          applyActiveState();
-          updateControls();
-          scrollToCard(activeIndex, smooth);
-        };
-
-        const findFirstVisibleIndex = () => {
-          const scrollLeft = viewport.scrollLeft;
-          let firstVisible = 0;
-
-          cards.forEach((card, index) => {
-            if (card.offsetLeft <= scrollLeft + 1) {
-              firstVisible = index;
-            }
-          });
-
-          return clampIndex(firstVisible);
-        };
-
-        let ticking = false;
-        const handleScroll = () => {
-          if (ticking) {
-            return;
-          }
-
-          ticking = true;
-          window.requestAnimationFrame(() => {
-            const closestIndex = findFirstVisibleIndex();
-            if (closestIndex !== activeIndex) {
-              activeIndex = closestIndex;
-              applyActiveState();
-              updateControls();
-            }
-            ticking = false;
-          });
-        };
-
-        prevButton?.addEventListener('click', () => goToCard(activeIndex - getCardsPerView()));
-        nextButton?.addEventListener('click', () => goToCard(activeIndex + getCardsPerView()));
-
-        viewport.addEventListener('scroll', handleScroll, { passive: true });
-        window.addEventListener('resize', () => goToCard(activeIndex, { smooth: false }));
-
-        window.requestAnimationFrame(() => {
-          goToCard(0, { smooth: false });
-        });
-
-      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the certifications carousel markup with a static grid of cards and drop unused navigation hint text
- convert certification styling to a responsive grid layout and remove carousel-specific CSS and JavaScript

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6e0c32978832aa380a2fd7ec135f7