### PR TITLE
Make layout responsive for mobile screens

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -118,6 +118,18 @@ li + li {
   margin-top: 0.45rem;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .container {
   width: var(--container-width);
   margin: 0 auto;
@@ -138,6 +150,71 @@ li + li {
   justify-content: space-between;
   padding: 1.25rem 0;
   gap: 1rem;
+}
+
+.topbar__toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(12, 16, 32, 0.85);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: border-color 180ms ease, background 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.topbar__toggle:hover,
+.topbar__toggle:focus-visible {
+  border-color: rgba(246, 183, 60, 0.65);
+  background: rgba(12, 16, 32, 0.95);
+  box-shadow: 0 12px 28px rgba(9, 12, 28, 0.45);
+  outline: none;
+}
+
+.topbar__toggle:focus-visible {
+  box-shadow: 0 0 0 3px rgba(246, 183, 60, 0.4);
+}
+
+.topbar__toggle-icon,
+.topbar__toggle-icon::before,
+.topbar__toggle-icon::after {
+  content: '';
+  display: block;
+  width: 20px;
+  height: 2px;
+  border-radius: 999px;
+  background: currentColor;
+  transition: transform 180ms ease, opacity 180ms ease;
+}
+
+.topbar__toggle-icon {
+  position: relative;
+}
+
+.topbar__toggle-icon::before {
+  position: absolute;
+  top: -6px;
+}
+
+.topbar__toggle-icon::after {
+  position: absolute;
+  bottom: -6px;
+}
+
+.topbar__toggle[aria-expanded='true'] .topbar__toggle-icon {
+  background: transparent;
+}
+
+.topbar__toggle[aria-expanded='true'] .topbar__toggle-icon::before {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.topbar__toggle[aria-expanded='true'] .topbar__toggle-icon::after {
+  transform: translateY(-6px) rotate(-45deg);
 }
 
 .brand {
@@ -700,6 +777,16 @@ li + li {
 }
 
 @media (max-width: 960px) {
+  .topbar__inner {
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem 1rem;
+  }
+
+  .menu {
+    justify-content: flex-start;
+  }
+
   .callout {
     flex-direction: column;
     align-items: flex-start;
@@ -740,5 +827,154 @@ li + li {
 @media (max-width: 720px) {
   .certifications-grid {
     grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  :root {
+    --topbar-offset: 84px;
+  }
+
+  .topbar__toggle {
+    display: inline-flex;
+  }
+
+  .menu {
+    width: 100%;
+    padding: 0.75rem 0 0.25rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    gap: 0.75rem;
+    flex-direction: column;
+  }
+
+  .menu[data-visible='false'] {
+    display: none;
+  }
+
+  .menu[data-visible='true'] {
+    display: grid;
+  }
+
+  .menu a {
+    display: block;
+    width: 100%;
+    padding: 0.5rem 0;
+  }
+
+  .hero {
+    padding: 4.25rem 0 3.25rem;
+  }
+
+  .hero__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .hero__actions .button {
+    width: 100%;
+  }
+
+  .hero__panel {
+    padding: 2rem 1.75rem;
+  }
+
+  .section {
+    padding: 4rem 0;
+  }
+
+  .feature-grid,
+  .competency-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline::before {
+    left: 12px;
+  }
+
+  .timeline__item {
+    padding: 1.2rem 1.2rem 1.35rem 3.25rem;
+  }
+
+  .stat-card,
+  .feature-card,
+  .competency-card,
+  .certification-card,
+  .testimonial-card {
+    padding: 1.5rem;
+  }
+}
+
+@media (max-width: 540px) {
+  :root {
+    --topbar-offset: 76px;
+  }
+
+  .brand {
+    gap: 0.75rem;
+  }
+
+  .brand__monogram {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    font-size: 1.1rem;
+  }
+
+  .brand__name {
+    font-size: 0.95rem;
+  }
+
+  .brand__role {
+    font-size: 0.8rem;
+  }
+
+  .hero__profile h1 {
+    font-size: clamp(2rem, 8vw, 2.6rem);
+  }
+
+  .hero__profile > p {
+    font-size: 1rem;
+  }
+
+  .hero__badge {
+    font-size: 0.78rem;
+  }
+
+  .hero__panel {
+    padding: 1.75rem 1.5rem;
+  }
+
+  .timeline__item {
+    padding-left: 2.85rem;
+  }
+
+  .timeline::before {
+    left: 10px;
+  }
+
+  .callout {
+    padding: 2.25rem 1.9rem;
+  }
+}
+
+@media (max-width: 420px) {
+  .topbar__inner {
+    padding: 1rem 0;
+  }
+
+  .hero {
+    padding: 3.75rem 0 3rem;
+  }
+
+  .hero__stats {
+    grid-template-columns: 1fr;
+  }
+
+  .stat-card__value {
+    font-size: 1.6rem;
+  }
+
+  .section {
+    padding: 3.5rem 0;
   }
 }

--- a/index.html
+++ b/index.html
@@ -26,7 +26,21 @@
             <p class="brand__role">Gerente de Projetos · Transformação Digital</p>
           </div>
         </div>
-        <nav class="menu" aria-label="Navegação principal">
+        <button
+          class="topbar__toggle"
+          type="button"
+          aria-expanded="false"
+          aria-controls="primary-nav"
+        >
+          <span class="sr-only">Alternar menu de navegação</span>
+          <span class="topbar__toggle-icon" aria-hidden="true"></span>
+        </button>
+        <nav
+          class="menu"
+          id="primary-nav"
+          aria-label="Navegação principal"
+          data-visible="false"
+        >
           <a href="#resumo">Sobre</a>
           <a href="#experiencia">Experiência</a>
           <a href="#formacao">Formação</a>
@@ -666,6 +680,56 @@
         const offset = topbar.offsetHeight + 24;
         document.documentElement.style.setProperty('--topbar-offset', `${offset}px`);
       };
+
+      const navigation = document.getElementById('primary-nav');
+      const navigationToggle = document.querySelector('.topbar__toggle');
+      const desktopQuery = window.matchMedia('(min-width: 721px)');
+
+      if (navigation && navigationToggle) {
+        const closeMenu = () => {
+          navigation.dataset.visible = 'false';
+          navigationToggle.setAttribute('aria-expanded', 'false');
+          updateTopbarOffset();
+        };
+
+        const setMenuForViewport = (mq) => {
+          if (mq.matches) {
+            navigation.dataset.visible = 'true';
+            navigationToggle.setAttribute('aria-expanded', 'false');
+          } else {
+            closeMenu();
+          }
+
+          updateTopbarOffset();
+        };
+
+        navigationToggle.addEventListener('click', () => {
+          const isExpanded = navigationToggle.getAttribute('aria-expanded') === 'true';
+          if (isExpanded) {
+            closeMenu();
+          } else {
+            navigation.dataset.visible = 'true';
+            navigationToggle.setAttribute('aria-expanded', 'true');
+            updateTopbarOffset();
+          }
+        });
+
+        navigation.querySelectorAll('a').forEach((link) => {
+          link.addEventListener('click', () => {
+            if (!desktopQuery.matches) {
+              closeMenu();
+            }
+          });
+        });
+
+        setMenuForViewport(desktopQuery);
+
+        if (typeof desktopQuery.addEventListener === 'function') {
+          desktopQuery.addEventListener('change', setMenuForViewport);
+        } else if (typeof desktopQuery.addListener === 'function') {
+          desktopQuery.addListener(setMenuForViewport);
+        }
+      }
 
       updateTopbarOffset();
       window.addEventListener('load', updateTopbarOffset);


### PR DESCRIPTION
## Summary
- add a collapsible mobile navigation toggle with accessible text
- tune spacing, typography, and grid layouts for smaller breakpoints across sections
- update the layout script to sync the sticky header offset with the responsive navigation state

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68da68e4e2c4832a9731069ef0a2f6d9