### PR TITLE
Fix certification tags alignment

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -630,6 +630,10 @@ li + li {
   box-shadow: var(--shadow-soft);
   position: relative;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.35rem;
   transition: transform 0.35s ease, box-shadow 0.35s ease, border-color 0.35s ease,
     background 0.35s ease;
 }
@@ -639,7 +643,7 @@ li + li {
 }
 
 .certification-card p {
-  margin-bottom: 1.4rem;
+  margin: 0;
 }
 
 .certification-card__tag {
@@ -653,6 +657,8 @@ li + li {
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+  margin-top: auto;
+  align-self: flex-end;
 }
 
 .certification-card--focus {


### PR DESCRIPTION
## Summary
- align certification tags to the bottom-right of each card for consistent layout

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68da728d79d4832aa618fed2c6fe933d