### PR TITLE
Create testimonial carousel

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -667,10 +667,143 @@ li + li {
   box-shadow: 0 32px 60px rgba(10, 13, 35, 0.7);
 }
 
-.testimonial-grid {
-  display: grid;
+.testimonial-carousel {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  padding-inline: clamp(0.5rem, 3vw, 1.5rem);
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.testimonial-carousel__viewport {
+  position: relative;
+  overflow: hidden;
+}
+
+.testimonial-carousel[data-enhanced='false'] .testimonial-carousel__viewport {
+  overflow: visible;
+}
+
+.testimonial-carousel__track {
+  display: flex;
+  align-items: stretch;
   gap: 2rem;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  transition: transform 380ms ease;
+  will-change: transform;
+}
+
+.testimonial-carousel[data-enhanced='false'] .testimonial-carousel__track {
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  transform: none !important;
+}
+
+.testimonial-carousel__slide {
+  flex: 0 0 100%;
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem 0;
+}
+
+.testimonial-carousel[data-enhanced='false'] .testimonial-carousel__slide {
+  flex: 1 1 320px;
+  justify-content: stretch;
+  padding: 0;
+}
+
+.testimonial-carousel__control {
+  position: absolute;
+  top: 50%;
+  width: 46px;
+  height: 46px;
+  border-radius: 999px;
+  border: 1px solid rgba(246, 183, 60, 0.55);
+  background: rgba(12, 16, 32, 0.9);
+  color: var(--color-accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 180ms ease, border-color 180ms ease, color 180ms ease, transform 180ms ease,
+    box-shadow 180ms ease;
+  box-shadow: 0 14px 34px rgba(10, 13, 35, 0.45);
+  z-index: 1;
+  transform: translateY(-50%);
+}
+
+.testimonial-carousel__control:hover,
+.testimonial-carousel__control:focus-visible {
+  background: rgba(246, 183, 60, 0.18);
+  border-color: rgba(246, 183, 60, 0.7);
+  color: var(--color-text);
+  transform: translateY(-50%) scale(1.05);
+  outline: none;
+}
+
+.testimonial-carousel__control:focus-visible {
+  box-shadow: 0 0 0 3px rgba(246, 183, 60, 0.35);
+}
+
+.testimonial-carousel__control:disabled {
+  opacity: 0.35;
+  border-color: rgba(255, 255, 255, 0.12);
+  color: rgba(229, 233, 255, 0.45);
+  background: rgba(12, 16, 32, 0.6);
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: translateY(-50%);
+}
+
+.testimonial-carousel__control--prev {
+  left: clamp(0.25rem, 3vw, 1.25rem);
+}
+
+.testimonial-carousel__control--next {
+  right: clamp(0.25rem, 3vw, 1.25rem);
+}
+
+.testimonial-carousel__indicators {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  padding-bottom: 0.5rem;
+}
+
+.testimonial-carousel__indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(246, 183, 60, 0.55);
+  background: rgba(246, 183, 60, 0.15);
+  padding: 0;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, border-color 160ms ease, opacity 160ms ease;
+}
+
+.testimonial-carousel__indicator:hover,
+.testimonial-carousel__indicator:focus-visible {
+  background: rgba(246, 183, 60, 0.4);
+  border-color: rgba(246, 183, 60, 0.8);
+  outline: none;
+}
+
+.testimonial-carousel__indicator:focus-visible {
+  box-shadow: 0 0 0 2px rgba(246, 183, 60, 0.35);
+}
+
+.testimonial-carousel__indicator.is-active {
+  background: var(--color-accent);
+  border-color: rgba(246, 183, 60, 0.95);
+  transform: scale(1.15);
+}
+
+.testimonial-carousel--single .testimonial-carousel__control,
+.testimonial-carousel--single .testimonial-carousel__indicators {
+  display: none;
 }
 
 .testimonial-card {
@@ -684,6 +817,7 @@ li + li {
   box-shadow: var(--shadow-soft);
   position: relative;
   overflow: hidden;
+  width: min(640px, 100%);
 }
 
 .testimonial-card::before {
@@ -766,19 +900,47 @@ li + li {
   text-transform: uppercase;
 }
 
+@media (max-width: 900px) {
+  .testimonial-carousel {
+    padding-inline: clamp(0.25rem, 4vw, 1rem);
+  }
+}
+
 @media (max-width: 640px) {
   .testimonial-card {
     padding: 1.5rem;
   }
 
-  .testimonial-grid {
-    grid-template-columns: 1fr;
+  .testimonial-carousel {
+    padding-inline: 0;
+  }
+
+  .testimonial-carousel__slide {
+    padding: 0;
+  }
+
+  .testimonial-carousel__control {
+    width: 40px;
+    height: 40px;
+  }
+
+  .testimonial-carousel__control--prev {
+    left: 0.5rem;
+  }
+
+  .testimonial-carousel__control--next {
+    right: 0.5rem;
   }
 }
 
-@media (max-width: 1080px) {
-  .testimonial-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+@media (max-width: 480px) {
+  .testimonial-carousel__indicators {
+    gap: 0.5rem;
+  }
+
+  .testimonial-carousel__indicator {
+    width: 10px;
+    height: 10px;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -499,139 +499,189 @@
               conectar estratégia, execução e relacionamento com stakeholders.
             </p>
           </header>
-          <div class="testimonial-grid">
-            <article class="testimonial-card">
-              <header class="testimonial-card__header">
-                <h3 class="testimonial-card__name">Rebeca Andrade</h3>
-                <p class="testimonial-card__role">
-                  Learning Experience Designer · Content Designer · Learning &amp; Development Consultant
-                </p>
-              </header>
-              <p class="testimonial-card__context">7 dez 2021 · Trabalhou comigo na Educacross</p>
-              <blockquote class="testimonial-card__quote">
-                <p>
-                  “O Leo tem em si qualidades muito caras a um excelente profissional: integridade, honestidade, capacidade de
-                  encorajar o time, foco em resultados e adaptação. Se eu pudesse resumí-lo, diria que ele é um profissional
-                  incansável! Trabalhar com ele foi uma experiência inesquecível.”
-                </p>
-              </blockquote>
-              <footer class="testimonial-card__footer">
-                <span class="testimonial-card__competencies">Competências citadas: liderança de times, foco em resultados, adaptabilidade.</span>
-                <span class="testimonial-card__relationship">1º grau</span>
-              </footer>
-            </article>
+          <div class="testimonial-carousel" data-carousel data-enhanced="false">
+            <button
+              class="testimonial-carousel__control testimonial-carousel__control--prev"
+              type="button"
+              data-carousel-prev
+              aria-label="Ver depoimento anterior"
+            >
+              <span aria-hidden="true">&#8249;</span>
+            </button>
+            <div class="testimonial-carousel__viewport">
+              <div class="testimonial-carousel__track" data-carousel-track>
+                <div class="testimonial-carousel__slide" data-carousel-slide>
+                  <article class="testimonial-card">
+                    <header class="testimonial-card__header">
+                      <h3 class="testimonial-card__name">Rebeca Andrade</h3>
+                      <p class="testimonial-card__role">
+                        Learning Experience Designer · Content Designer · Learning &amp; Development Consultant
+                      </p>
+                    </header>
+                    <p class="testimonial-card__context">7 dez 2021 · Trabalhou comigo na Educacross</p>
+                    <blockquote class="testimonial-card__quote">
+                      <p>
+                        “O Leo tem em si qualidades muito caras a um excelente profissional: integridade, honestidade,
+                        capacidade de encorajar o time, foco em resultados e adaptação. Se eu pudesse resumí-lo, diria que ele
+                        é um profissional incansável! Trabalhar com ele foi uma experiência inesquecível.”
+                      </p>
+                    </blockquote>
+                    <footer class="testimonial-card__footer">
+                      <span class="testimonial-card__competencies"
+                        >Competências citadas: liderança de times, foco em resultados, adaptabilidade.</span
+                      >
+                      <span class="testimonial-card__relationship">1º grau</span>
+                    </footer>
+                  </article>
+                </div>
 
-            <article class="testimonial-card">
-              <header class="testimonial-card__header">
-                <h3 class="testimonial-card__name">Endhe Soares</h3>
-                <p class="testimonial-card__role">Engineering Leader · Head of Engineering · ex-Nubank</p>
-              </header>
-              <p class="testimonial-card__context">26 jul 2021 · Gerenciou meu trabalho na Conexia Educação</p>
-              <blockquote class="testimonial-card__quote">
-                <p>
-                  “Leo é um grande profissional. Tem genuína preocupação com o bem-estar do time e com a entrega de
-                  resultados. É uma pessoa equilibrada que traduz necessidades e demandas do produto em resultados
-                  excepcionais.”
-                </p>
-              </blockquote>
-              <footer class="testimonial-card__footer">
-                <span class="testimonial-card__competencies">Competências citadas: cuidado com pessoas, entrega consistente, visão de produto.</span>
-                <span class="testimonial-card__relationship">Gestor direto</span>
-              </footer>
-            </article>
+                <div class="testimonial-carousel__slide" data-carousel-slide>
+                  <article class="testimonial-card">
+                    <header class="testimonial-card__header">
+                      <h3 class="testimonial-card__name">Endhe Soares</h3>
+                      <p class="testimonial-card__role">Engineering Leader · Head of Engineering · ex-Nubank</p>
+                    </header>
+                    <p class="testimonial-card__context">26 jul 2021 · Gerenciou meu trabalho na Conexia Educação</p>
+                    <blockquote class="testimonial-card__quote">
+                      <p>
+                        “Leo é um grande profissional. Tem genuína preocupação com o bem-estar do time e com a entrega de
+                        resultados. É uma pessoa equilibrada que traduz necessidades e demandas do produto em resultados
+                        excepcionais.”
+                      </p>
+                    </blockquote>
+                    <footer class="testimonial-card__footer">
+                      <span class="testimonial-card__competencies"
+                        >Competências citadas: cuidado com pessoas, entrega consistente, visão de produto.</span
+                      >
+                      <span class="testimonial-card__relationship">Gestor direto</span>
+                    </footer>
+                  </article>
+                </div>
 
-            <article class="testimonial-card">
-              <header class="testimonial-card__header">
-                <h3 class="testimonial-card__name">Denise Vallone Maggi</h3>
-                <p class="testimonial-card__role">CRM · Business Intelligence · Growth Marketing</p>
-              </header>
-              <p class="testimonial-card__context">30 ago 2021 · Atuamos em projetos conjuntos</p>
-              <blockquote class="testimonial-card__quote">
-                <p>
-                  “O Leo, além de um grande profissional, é uma pessoa inspiradora e proativa. Possui excelente habilidade em
-                  coordenação de projetos e liderança de equipe, sempre muito atencioso e organizado.”
-                </p>
-              </blockquote>
-              <footer class="testimonial-card__footer">
-                <span class="testimonial-card__competencies">Competências citadas: coordenação de projetos, liderança de equipe, organização.</span>
-                <span class="testimonial-card__relationship">Parceira de squad</span>
-              </footer>
-            </article>
+                <div class="testimonial-carousel__slide" data-carousel-slide>
+                  <article class="testimonial-card">
+                    <header class="testimonial-card__header">
+                      <h3 class="testimonial-card__name">Denise Vallone Maggi</h3>
+                      <p class="testimonial-card__role">CRM · Business Intelligence · Growth Marketing</p>
+                    </header>
+                    <p class="testimonial-card__context">30 ago 2021 · Atuamos em projetos conjuntos</p>
+                    <blockquote class="testimonial-card__quote">
+                      <p>
+                        “O Leo, além de um grande profissional, é uma pessoa inspiradora e proativa. Possui excelente
+                        habilidade em coordenação de projetos e liderança de equipe, sempre muito atencioso e organizado.”
+                      </p>
+                    </blockquote>
+                    <footer class="testimonial-card__footer">
+                      <span class="testimonial-card__competencies"
+                        >Competências citadas: coordenação de projetos, liderança de equipe, organização.</span
+                      >
+                      <span class="testimonial-card__relationship">Parceira de squad</span>
+                    </footer>
+                  </article>
+                </div>
 
-            <article class="testimonial-card">
-              <header class="testimonial-card__header">
-                <h3 class="testimonial-card__name">Joeriverson Santos</h3>
-                <p class="testimonial-card__role">Coordenador de Projetos e PMO · Pleno</p>
-              </header>
-              <p class="testimonial-card__context">27 ago 2021 · Trabalhou comigo na Conexia Educação</p>
-              <blockquote class="testimonial-card__quote">
-                <p>
-                  “Leonardo é um excelente profissional, sempre disposto a ajudar e a aprender novas coisas. Trabalhamos juntos
-                  na Conexia, onde pude observar seu comprometimento, proatividade e inteligência emocional.”
-                </p>
-              </blockquote>
-              <footer class="testimonial-card__footer">
-                <span class="testimonial-card__competencies">Competências citadas: proatividade, inteligência emocional, colaboração.</span>
-                <span class="testimonial-card__relationship">1º grau</span>
-              </footer>
-            </article>
+                <div class="testimonial-carousel__slide" data-carousel-slide>
+                  <article class="testimonial-card">
+                    <header class="testimonial-card__header">
+                      <h3 class="testimonial-card__name">Joeriverson Santos</h3>
+                      <p class="testimonial-card__role">Coordenador de Projetos e PMO · Pleno</p>
+                    </header>
+                    <p class="testimonial-card__context">27 ago 2021 · Trabalhou comigo na Conexia Educação</p>
+                    <blockquote class="testimonial-card__quote">
+                      <p>
+                        “Leonardo é um excelente profissional, sempre disposto a ajudar e a aprender novas coisas. Trabalhamos
+                        juntos na Conexia, onde pude observar seu comprometimento, proatividade e inteligência emocional.”
+                      </p>
+                    </blockquote>
+                    <footer class="testimonial-card__footer">
+                      <span class="testimonial-card__competencies"
+                        >Competências citadas: proatividade, inteligência emocional, colaboração.</span
+                      >
+                      <span class="testimonial-card__relationship">1º grau</span>
+                    </footer>
+                  </article>
+                </div>
 
-            <article class="testimonial-card">
-              <header class="testimonial-card__header">
-                <h3 class="testimonial-card__name">Marcel Santos</h3>
-                <p class="testimonial-card__role">Product Manager · Agile Coach · SAFe Practitioner</p>
-              </header>
-              <p class="testimonial-card__context">27 ago 2021 · Atuamos em tribos diferentes na Conexia</p>
-              <blockquote class="testimonial-card__quote">
-                <p>
-                  “Leo é um profissional completo. Possui forte capacidade para mentorar Product Owners, mantendo alto
-                  alinhamento entre stakeholders e times Scrum. Entrega valor consistente em múltiplos projetos.”
-                </p>
-              </blockquote>
-              <footer class="testimonial-card__footer">
-                <span class="testimonial-card__competencies">Competências citadas: mentoria, governança ágil, entrega de valor.</span>
-                <span class="testimonial-card__relationship">1º grau</span>
-              </footer>
-            </article>
+                <div class="testimonial-carousel__slide" data-carousel-slide>
+                  <article class="testimonial-card">
+                    <header class="testimonial-card__header">
+                      <h3 class="testimonial-card__name">Marcel Santos</h3>
+                      <p class="testimonial-card__role">Product Manager · Agile Coach · SAFe Practitioner</p>
+                    </header>
+                    <p class="testimonial-card__context">27 ago 2021 · Atuamos em tribos diferentes na Conexia</p>
+                    <blockquote class="testimonial-card__quote">
+                      <p>
+                        “Leo é um profissional completo. Possui forte capacidade para mentorar Product Owners, mantendo alto
+                        alinhamento entre stakeholders e times Scrum. Entrega valor consistente em múltiplos projetos.”
+                      </p>
+                    </blockquote>
+                    <footer class="testimonial-card__footer">
+                      <span class="testimonial-card__competencies"
+                        >Competências citadas: mentoria, governança ágil, entrega de valor.</span
+                      >
+                      <span class="testimonial-card__relationship">1º grau</span>
+                    </footer>
+                  </article>
+                </div>
 
-            <article class="testimonial-card">
-              <header class="testimonial-card__header">
-                <h3 class="testimonial-card__name">Leonardo Brito Bittencourt</h3>
-                <p class="testimonial-card__role">Senior Software Engineer · Full Stack · TypeScript · Node.js · React</p>
-              </header>
-              <p class="testimonial-card__context">11 mar 2021 · Co-lideramos squads na Conexia Educação</p>
-              <blockquote class="testimonial-card__quote">
-                <p>
-                  “Leonardo é um excelente profissional e uma ótima pessoa. Tive a oportunidade de estar ao lado dele por anos,
-                  sendo co-coordenadores de squads na Conexia Educação. É criativo, orientado a resultados e multidisciplinar.”
-                </p>
-              </blockquote>
-              <footer class="testimonial-card__footer">
-                <span class="testimonial-card__competencies">Competências citadas: co-liderança de squads, criatividade, foco em resultados.</span>
-                <span class="testimonial-card__relationship">Parceiro técnico</span>
-              </footer>
-            </article>
+                <div class="testimonial-carousel__slide" data-carousel-slide>
+                  <article class="testimonial-card">
+                    <header class="testimonial-card__header">
+                      <h3 class="testimonial-card__name">Leonardo Brito Bittencourt</h3>
+                      <p class="testimonial-card__role">Senior Software Engineer · Full Stack · TypeScript · Node.js · React</p>
+                    </header>
+                    <p class="testimonial-card__context">11 mar 2021 · Co-lideramos squads na Conexia Educação</p>
+                    <blockquote class="testimonial-card__quote">
+                      <p>
+                        “Leonardo é um excelente profissional e uma ótima pessoa. Tive a oportunidade de estar ao lado dele por
+                        anos, sendo co-coordenadores de squads na Conexia Educação. É criativo, orientado a resultados e
+                        multidisciplinar.”
+                      </p>
+                    </blockquote>
+                    <footer class="testimonial-card__footer">
+                      <span class="testimonial-card__competencies"
+                        >Competências citadas: co-liderança de squads, criatividade, foco em resultados.</span
+                      >
+                      <span class="testimonial-card__relationship">Parceiro técnico</span>
+                    </footer>
+                  </article>
+                </div>
 
-            <article class="testimonial-card">
-              <header class="testimonial-card__header">
-                <h3 class="testimonial-card__name">Karen Kroll</h3>
-                <p class="testimonial-card__role">
-                  Consultora em Inovação · Programas de Crescimento · Governança do Conhecimento
-                </p>
-              </header>
-              <p class="testimonial-card__context">12 fev 2021 · Trabalhou comigo na Conexia Educação</p>
-              <blockquote class="testimonial-card__quote">
-                <p>
-                  “Tive a grata oportunidade de trabalhar com Leonardo, profissional extremamente competente, focado em ótimas
-                  entregas e fortalecedor de experiências imersivas. Ele domina a gestão de stakeholders, cultiva ritos
-                  colaborativos e promove resultados de alto impacto.”
-                </p>
-              </blockquote>
-              <footer class="testimonial-card__footer">
-                <span class="testimonial-card__competencies">Competências citadas: gestão de stakeholders, facilitação de ritos, impacto em experiências.</span>
-                <span class="testimonial-card__relationship">1º grau</span>
-              </footer>
-            </article>
+                <div class="testimonial-carousel__slide" data-carousel-slide>
+                  <article class="testimonial-card">
+                    <header class="testimonial-card__header">
+                      <h3 class="testimonial-card__name">Karen Kroll</h3>
+                      <p class="testimonial-card__role">
+                        Consultora em Inovação · Programas de Crescimento · Governança do Conhecimento
+                      </p>
+                    </header>
+                    <p class="testimonial-card__context">12 fev 2021 · Trabalhou comigo na Conexia Educação</p>
+                    <blockquote class="testimonial-card__quote">
+                      <p>
+                        “Tive a grata oportunidade de trabalhar com Leonardo, profissional extremamente competente, focado em
+                        ótimas entregas e fortalecedor de experiências imersivas. Ele domina a gestão de stakeholders, cultiva
+                        ritos colaborativos e promove resultados de alto impacto.”
+                      </p>
+                    </blockquote>
+                    <footer class="testimonial-card__footer">
+                      <span class="testimonial-card__competencies"
+                        >Competências citadas: gestão de stakeholders, facilitação de ritos, impacto em experiências.</span
+                      >
+                      <span class="testimonial-card__relationship">1º grau</span>
+                    </footer>
+                  </article>
+                </div>
+              </div>
+            </div>
+            <button
+              class="testimonial-carousel__control testimonial-carousel__control--next"
+              type="button"
+              data-carousel-next
+              aria-label="Ver próximo depoimento"
+            >
+              <span aria-hidden="true">&#8250;</span>
+            </button>
+            <div class="testimonial-carousel__indicators" data-carousel-indicators aria-label="Progresso dos depoimentos"></div>
           </div>
         </div>
       </section>
@@ -730,6 +780,190 @@
           desktopQuery.addListener(setMenuForViewport);
         }
       }
+
+      const initializeTestimonialCarousels = () => {
+        const carousels = document.querySelectorAll('[data-carousel]');
+        if (!carousels.length) {
+          return;
+        }
+
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+        carousels.forEach((carousel, carouselIndex) => {
+          const track = carousel.querySelector('[data-carousel-track]');
+          const slides = track ? Array.from(track.querySelectorAll('[data-carousel-slide]')) : [];
+
+          if (!track || !slides.length) {
+            return;
+          }
+
+          const prevButton = carousel.querySelector('[data-carousel-prev]');
+          const nextButton = carousel.querySelector('[data-carousel-next]');
+          const indicatorsWrapper = carousel.querySelector('[data-carousel-indicators]');
+          const indicatorButtons = [];
+
+          carousel.dataset.enhanced = 'true';
+          carousel.dataset.activeIndex = '0';
+
+          if (slides.length <= 1) {
+            carousel.classList.add('testimonial-carousel--single');
+            if (prevButton) {
+              prevButton.disabled = true;
+            }
+            if (nextButton) {
+              nextButton.disabled = true;
+            }
+            if (indicatorsWrapper) {
+              indicatorsWrapper.innerHTML = '';
+            }
+            return;
+          }
+
+          if (indicatorsWrapper) {
+            indicatorsWrapper.innerHTML = '';
+          }
+
+          slides.forEach((slide, slideIndex) => {
+            const slideId = slide.id || `testimonial-slide-${carouselIndex + 1}-${slideIndex + 1}`;
+            slide.id = slideId;
+            slide.setAttribute('role', 'group');
+            slide.setAttribute('aria-roledescription', 'slide');
+            slide.setAttribute('aria-label', `Depoimento ${slideIndex + 1} de ${slides.length}`);
+            slide.setAttribute('aria-hidden', slideIndex === 0 ? 'false' : 'true');
+
+            if (indicatorsWrapper) {
+              const indicatorButton = document.createElement('button');
+              indicatorButton.type = 'button';
+              indicatorButton.className = 'testimonial-carousel__indicator';
+              const personName = slide.querySelector('.testimonial-card__name')?.textContent?.trim();
+              indicatorButton.setAttribute(
+                'aria-label',
+                personName
+                  ? `Ir para depoimento de ${personName}`
+                  : `Ir para depoimento ${slideIndex + 1}`,
+              );
+              indicatorButton.setAttribute('aria-controls', slideId);
+              indicatorsWrapper.appendChild(indicatorButton);
+              indicatorButtons.push(indicatorButton);
+            }
+          });
+
+          let activeIndex = 0;
+
+          const goToSlide = (targetIndex, options = {}) => {
+            const { focusIndicator = false, force = false } = options;
+            const normalizedIndex = Math.max(0, Math.min(slides.length - 1, targetIndex));
+
+            if (normalizedIndex === activeIndex && !force) {
+              return;
+            }
+
+            activeIndex = normalizedIndex;
+            const activeSlide = slides[activeIndex];
+            const offset = activeSlide.offsetLeft;
+
+            if (prefersReducedMotion.matches) {
+              track.style.transitionDuration = '0ms';
+            } else {
+              track.style.transitionDuration = '';
+            }
+
+            track.style.transform = `translateX(-${offset}px)`;
+
+            slides.forEach((slide, index) => {
+              slide.setAttribute('aria-hidden', index === activeIndex ? 'false' : 'true');
+            });
+
+            if (prevButton) {
+              prevButton.disabled = activeIndex === 0;
+            }
+
+            if (nextButton) {
+              nextButton.disabled = activeIndex === slides.length - 1;
+            }
+
+            indicatorButtons.forEach((indicator, index) => {
+              const isActive = index === activeIndex;
+              indicator.classList.toggle('is-active', isActive);
+              if (isActive) {
+                indicator.setAttribute('aria-current', 'true');
+                if (focusIndicator) {
+                  indicator.focus();
+                }
+              } else {
+                indicator.removeAttribute('aria-current');
+              }
+            });
+
+            carousel.dataset.activeIndex = String(activeIndex);
+          };
+
+          prevButton?.addEventListener('click', () => {
+            goToSlide(activeIndex - 1);
+          });
+
+          nextButton?.addEventListener('click', () => {
+            goToSlide(activeIndex + 1);
+          });
+
+          indicatorButtons.forEach((indicator, index) => {
+            indicator.addEventListener('click', () => {
+              goToSlide(index);
+            });
+
+            indicator.addEventListener('keydown', (event) => {
+              if (event.key === 'ArrowLeft') {
+                event.preventDefault();
+                goToSlide(index - 1, { focusIndicator: true });
+              } else if (event.key === 'ArrowRight') {
+                event.preventDefault();
+                goToSlide(index + 1, { focusIndicator: true });
+              }
+            });
+          });
+
+          carousel.addEventListener('keydown', (event) => {
+            if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+              return;
+            }
+
+            if (event.target instanceof HTMLElement && event.target.closest('[data-carousel-indicators]')) {
+              return;
+            }
+
+            if (event.target instanceof HTMLElement) {
+              const tagName = event.target.tagName.toLowerCase();
+              if (tagName === 'input' || tagName === 'textarea') {
+                return;
+              }
+            }
+
+            if (event.key === 'ArrowLeft') {
+              goToSlide(activeIndex - 1);
+            } else {
+              goToSlide(activeIndex + 1);
+            }
+          });
+
+          let resizeFrame;
+          const handleResize = () => {
+            if (resizeFrame) {
+              cancelAnimationFrame(resizeFrame);
+            }
+
+            resizeFrame = requestAnimationFrame(() => {
+              goToSlide(activeIndex, { force: true });
+            });
+          };
+
+          window.addEventListener('resize', handleResize);
+          window.addEventListener('orientationchange', handleResize);
+
+          goToSlide(0, { force: true });
+        });
+      };
+
+      initializeTestimonialCarousels();
 
       updateTopbarOffset();
       window.addEventListener('load', updateTopbarOffset);


### PR DESCRIPTION
## Summary
- convert the testimonials grid into a single-card carousel with navigation controls and indicators
- add carousel-specific styling and responsive refinements to match the site's look and feel
- enhance the page script to initialize the carousel with keyboard support and motion preferences
- fix the carousel width overflow so it stays aligned with the surrounding content

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da750a3b64832ab28619439dbf6168