### PR TITLE
Adopt testimonial carousel for certifications section

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -616,12 +616,6 @@ li + li {
   box-shadow: var(--shadow-soft);
 }
 
-.certifications-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1.75rem;
-}
-
 .certification-card {
   background: var(--color-surface-alt);
   border-radius: var(--radius-md);
@@ -665,6 +659,40 @@ li + li {
   border: 1px solid rgba(246, 183, 60, 0.55);
   background: linear-gradient(150deg, rgba(246, 183, 60, 0.16), rgba(91, 128, 255, 0.1));
   box-shadow: 0 32px 60px rgba(10, 13, 35, 0.7);
+}
+
+.certifications-carousel .testimonial-carousel__track {
+  gap: 1.5rem;
+}
+
+.certifications-carousel .testimonial-carousel__slide {
+  justify-content: stretch;
+  padding: 0;
+}
+
+.certifications-slide-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+  width: 100%;
+}
+
+.certifications-carousel .certification-card {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+@media (max-width: 1080px) {
+  .certifications-slide-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .certifications-slide-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .testimonial-carousel {
@@ -983,18 +1011,6 @@ li + li {
     min-width: 0;
     width: 100%;
     justify-content: center;
-  }
-}
-
-@media (max-width: 1080px) {
-  .certifications-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 720px) {
-  .certifications-grid {
-    grid-template-columns: repeat(1, minmax(0, 1fr));
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -414,77 +414,148 @@
             <h2>Certificações &amp; Cursos</h2>
             <p>Capacitações que fortalecem a atuação em gestão de projetos e produtos digitais.</p>
           </header>
-          <div class="certifications-grid">
-            <article class="certification-card">
-              <h3>Transitioning from Waterfall to Agile Project Management</h3>
-              <p>LinkedIn Learning · Emitido jan 2020</p>
-              <span class="certification-card__tag">Agile Leadership</span>
-            </article>
-            <article class="certification-card">
-              <h3>Scrum: Advanced</h3>
-              <p>LinkedIn Learning · Emitido jan 2020</p>
-              <span class="certification-card__tag">Scrum Mastery</span>
-            </article>
-            <article class="certification-card">
-              <h3>OKR Bootcamp</h3>
-              <p>Sympla · Emitido jul 2019</p>
-              <span class="certification-card__tag">Governança &amp; Métricas</span>
-            </article>
-            <article class="certification-card">
-              <h3>Kanban Foundation Certificate</h3>
-              <p>Certiprof · Emitido set 2020</p>
-              <span class="certification-card__tag">Fluxo Contínuo</span>
-            </article>
-            <article class="certification-card">
-              <h3>JavaScript: explorando a manipulação de elementos e da localStorage</h3>
-              <p>Alura · Emitido fev 2024</p>
-              <span class="certification-card__tag">Front-end</span>
-            </article>
-            <article class="certification-card">
-              <h3>JavaScript na Web: armazenando dados no navegador</h3>
-              <p>Alura · Emitido fev 2024</p>
-              <span class="certification-card__tag">Front-end</span>
-            </article>
-            <article class="certification-card">
-              <h3>JavaScript para Web: Crie páginas dinâmicas</h3>
-              <p>Alura · Emitido fev 2024</p>
-              <span class="certification-card__tag">Front-end</span>
-            </article>
-            <article class="certification-card">
-              <h3>JavaScript: consumindo e tratando dados de uma API</h3>
-              <p>Alura · Emitido fev 2024</p>
-              <span class="certification-card__tag">Integrações</span>
-            </article>
-            <article class="certification-card">
-              <h3>JavaScript: manipulando o DOM</h3>
-              <p>Alura · Emitido fev 2024</p>
-              <span class="certification-card__tag">Interatividade</span>
-            </article>
-            <article class="certification-card">
-              <h3>JavaScript: validações e reconhecimento de voz</h3>
-              <p>Alura · Emitido fev 2024</p>
-              <span class="certification-card__tag">Experiência do Usuário</span>
-            </article>
-            <article class="certification-card">
-              <h3>HTML e CSS: ambientes de desenvolvimento, estrutura e tags</h3>
-              <p>Alura · Emitido jan 2024</p>
-              <span class="certification-card__tag">Fundamentos Web</span>
-            </article>
-            <article class="certification-card">
-              <h3>HTML e CSS: cabeçalho, footer e variáveis CSS</h3>
-              <p>Alura · Emitido jan 2024</p>
-              <span class="certification-card__tag">UI Engineering</span>
-            </article>
-            <article class="certification-card">
-              <h3>HTML e CSS: classes, posicionamento e Flexbox</h3>
-              <p>Alura · Emitido jan 2024</p>
-              <span class="certification-card__tag">Layout</span>
-            </article>
-            <article class="certification-card">
-              <h3>HTML e CSS: praticando HTML/CSS</h3>
-              <p>Alura · Emitido jan 2024</p>
-              <span class="certification-card__tag">Boas Práticas</span>
-            </article>
+          <div
+            class="testimonial-carousel certifications-carousel"
+            data-carousel
+            data-enhanced="false"
+            data-carousel-item-label="Conjunto de certificações"
+            data-carousel-indicator-prefix="Ir para conjunto de"
+          >
+            <button
+              class="testimonial-carousel__control testimonial-carousel__control--prev"
+              type="button"
+              data-carousel-prev
+              aria-label="Ver conjunto anterior de certificações"
+            >
+              <span aria-hidden="true">&#8249;</span>
+            </button>
+            <div class="testimonial-carousel__viewport">
+              <div class="testimonial-carousel__track" data-carousel-track>
+                <div
+                  class="testimonial-carousel__slide"
+                  data-carousel-slide
+                  data-carousel-label="Certificações 1 a 3"
+                >
+                  <div class="certifications-slide-grid">
+                    <article class="certification-card">
+                      <h3>Transitioning from Waterfall to Agile Project Management</h3>
+                      <p>LinkedIn Learning · Emitido jan 2020</p>
+                      <span class="certification-card__tag">Agile Leadership</span>
+                    </article>
+                    <article class="certification-card">
+                      <h3>Scrum: Advanced</h3>
+                      <p>LinkedIn Learning · Emitido jan 2020</p>
+                      <span class="certification-card__tag">Scrum Mastery</span>
+                    </article>
+                    <article class="certification-card">
+                      <h3>OKR Bootcamp</h3>
+                      <p>Sympla · Emitido jul 2019</p>
+                      <span class="certification-card__tag">Governança &amp; Métricas</span>
+                    </article>
+                  </div>
+                </div>
+                <div
+                  class="testimonial-carousel__slide"
+                  data-carousel-slide
+                  data-carousel-label="Certificações 4 a 6"
+                >
+                  <div class="certifications-slide-grid">
+                    <article class="certification-card">
+                      <h3>Kanban Foundation Certificate</h3>
+                      <p>Certiprof · Emitido set 2020</p>
+                      <span class="certification-card__tag">Fluxo Contínuo</span>
+                    </article>
+                    <article class="certification-card">
+                      <h3>JavaScript: explorando a manipulação de elementos e da localStorage</h3>
+                      <p>Alura · Emitido fev 2024</p>
+                      <span class="certification-card__tag">Front-end</span>
+                    </article>
+                    <article class="certification-card">
+                      <h3>JavaScript na Web: armazenando dados no navegador</h3>
+                      <p>Alura · Emitido fev 2024</p>
+                      <span class="certification-card__tag">Front-end</span>
+                    </article>
+                  </div>
+                </div>
+                <div
+                  class="testimonial-carousel__slide"
+                  data-carousel-slide
+                  data-carousel-label="Certificações 7 a 9"
+                >
+                  <div class="certifications-slide-grid">
+                    <article class="certification-card">
+                      <h3>JavaScript para Web: Crie páginas dinâmicas</h3>
+                      <p>Alura · Emitido fev 2024</p>
+                      <span class="certification-card__tag">Front-end</span>
+                    </article>
+                    <article class="certification-card">
+                      <h3>JavaScript: consumindo e tratando dados de uma API</h3>
+                      <p>Alura · Emitido fev 2024</p>
+                      <span class="certification-card__tag">Integrações</span>
+                    </article>
+                    <article class="certification-card">
+                      <h3>JavaScript: manipulando o DOM</h3>
+                      <p>Alura · Emitido fev 2024</p>
+                      <span class="certification-card__tag">Interatividade</span>
+                    </article>
+                  </div>
+                </div>
+                <div
+                  class="testimonial-carousel__slide"
+                  data-carousel-slide
+                  data-carousel-label="Certificações 10 a 12"
+                >
+                  <div class="certifications-slide-grid">
+                    <article class="certification-card">
+                      <h3>JavaScript: validações e reconhecimento de voz</h3>
+                      <p>Alura · Emitido fev 2024</p>
+                      <span class="certification-card__tag">Experiência do Usuário</span>
+                    </article>
+                    <article class="certification-card">
+                      <h3>HTML e CSS: ambientes de desenvolvimento, estrutura e tags</h3>
+                      <p>Alura · Emitido jan 2024</p>
+                      <span class="certification-card__tag">Fundamentos Web</span>
+                    </article>
+                    <article class="certification-card">
+                      <h3>HTML e CSS: cabeçalho, footer e variáveis CSS</h3>
+                      <p>Alura · Emitido jan 2024</p>
+                      <span class="certification-card__tag">UI Engineering</span>
+                    </article>
+                  </div>
+                </div>
+                <div
+                  class="testimonial-carousel__slide"
+                  data-carousel-slide
+                  data-carousel-label="Certificações 13 e 14"
+                >
+                  <div class="certifications-slide-grid">
+                    <article class="certification-card">
+                      <h3>HTML e CSS: classes, posicionamento e Flexbox</h3>
+                      <p>Alura · Emitido jan 2024</p>
+                      <span class="certification-card__tag">Layout</span>
+                    </article>
+                    <article class="certification-card">
+                      <h3>HTML e CSS: praticando HTML/CSS</h3>
+                      <p>Alura · Emitido jan 2024</p>
+                      <span class="certification-card__tag">Boas Práticas</span>
+                    </article>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <button
+              class="testimonial-carousel__control testimonial-carousel__control--next"
+              type="button"
+              data-carousel-next
+              aria-label="Ver próximo conjunto de certificações"
+            >
+              <span aria-hidden="true">&#8250;</span>
+            </button>
+            <div
+              class="testimonial-carousel__indicators"
+              data-carousel-indicators
+              aria-label="Progresso das certificações"
+            ></div>
           </div>
         </div>
       </section>
@@ -801,6 +872,9 @@
           const nextButton = carousel.querySelector('[data-carousel-next]');
           const indicatorsWrapper = carousel.querySelector('[data-carousel-indicators]');
           const indicatorButtons = [];
+          const itemLabel = (carousel.dataset.carouselItemLabel || 'Depoimento').trim();
+          const itemLabelLower = itemLabel.toLowerCase();
+          const indicatorPrefix = (carousel.dataset.carouselIndicatorPrefix || 'Ir para').trim();
 
           carousel.dataset.enhanced = 'true';
           carousel.dataset.activeIndex = '0';
@@ -828,7 +902,9 @@
             slide.id = slideId;
             slide.setAttribute('role', 'group');
             slide.setAttribute('aria-roledescription', 'slide');
-            slide.setAttribute('aria-label', `Depoimento ${slideIndex + 1} de ${slides.length}`);
+            const explicitSlideLabel = slide.dataset.carouselLabel?.trim();
+            const computedSlideLabel = `${itemLabel} ${slideIndex + 1} de ${slides.length}`;
+            slide.setAttribute('aria-label', explicitSlideLabel || computedSlideLabel);
             slide.setAttribute('aria-hidden', slideIndex === 0 ? 'false' : 'true');
 
             if (indicatorsWrapper) {
@@ -836,12 +912,16 @@
               indicatorButton.type = 'button';
               indicatorButton.className = 'testimonial-carousel__indicator';
               const personName = slide.querySelector('.testimonial-card__name')?.textContent?.trim();
-              indicatorButton.setAttribute(
-                'aria-label',
-                personName
-                  ? `Ir para depoimento de ${personName}`
-                  : `Ir para depoimento ${slideIndex + 1}`,
-              );
+              const indicatorLabel = (() => {
+                if (personName) {
+                  return `${indicatorPrefix} ${itemLabelLower} de ${personName}`;
+                }
+                if (explicitSlideLabel) {
+                  return `${indicatorPrefix} ${explicitSlideLabel.toLowerCase()}`;
+                }
+                return `${indicatorPrefix} ${itemLabelLower} ${slideIndex + 1}`;
+              })();
+              indicatorButton.setAttribute('aria-label', indicatorLabel);
               indicatorButton.setAttribute('aria-controls', slideId);
               indicatorsWrapper.appendChild(indicatorButton);
               indicatorButtons.push(indicatorButton);


### PR DESCRIPTION
## Summary
- reuse the testimonial carousel component to display certifications in groups of three cards
- extend carousel script to support custom labels and indicator prefixes for different sections
- add responsive styles so certification slides arrange three, two or one cards depending on viewport

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68dad5e00400832aabc7e6d9ba2a1fbf