### PR TITLE
Fix carousel hover highlight clipping

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -708,7 +708,8 @@ li + li {
 
 .testimonial-carousel__viewport {
   position: relative;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: visible;
 }
 
 .testimonial-carousel[data-enhanced='false'] .testimonial-carousel__viewport {


### PR DESCRIPTION
## Summary
- allow the testimonial carousel viewport to expose vertical overflow so hover shadows on cards are no longer clipped

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68dae9c1ac14832aa45fc843954e87c0