### PR TITLE
Remove hover animation from certifications carousel

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -683,6 +683,13 @@ li + li {
   flex-direction: column;
 }
 
+.certifications-carousel .certification-card:hover {
+  transform: none;
+  box-shadow: var(--shadow-soft);
+  border-color: rgba(255, 255, 255, 0.07);
+  background: var(--color-surface-alt);
+}
+
 @media (max-width: 1080px) {
   .certifications-slide-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
## Summary
- stop certification cards inside the carousel from animating on hover so they remain static

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daebb2e1cc832a9821a8fb16c5c674