### PR TITLE
Destacar linhas de escala no gráfico radar

### DIFF
--- a/index.html
+++ b/index.html
@@ -863,11 +863,15 @@
                 ticks: {
                   showLabelBackdrop: false,
                   stepSize: 10,
+                  color: '#1f2937',
                 },
                 grid: {
                   circular: true,
+                  color: 'rgba(37, 99, 235, 0.25)',
+                  lineWidth: 1,
                 },
                 angleLines: {
+                  color: 'rgba(37, 99, 235, 0.35)',
                   lineWidth: 1,
                 },
                 pointLabels: {


### PR DESCRIPTION
## Summary
- ajusta o gráfico radar das competências para exibir linhas de escala mais evidentes
- define cores para a grade radial e linhas angulares para destacar os níveis de proficiência

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbc043a45c832ab8ff7a902d28809e