### PR TITLE
Remove explanatory copy from competency radar section

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,11 +324,6 @@
               <canvas id="competency-radar" role="img" aria-label="Gráfico radar destacando cinco competências"></canvas>
             </figure>
             <div class="competency-insight__legend">
-              <p>
-                Os eixos foram definidos a partir dos destaques mais recorrentes do portfólio: liderança de pessoas,
-                governança de PMO, visão estratégica de produto, agilidade em processos e comunicação executiva. Cada
-                nível representa a intensidade dessas habilidades descritas ao longo do site.
-              </p>
               <dl class="competency-insight__scale">
                 <div>
                   <dt>Liderança de Pessoas</dt>


### PR DESCRIPTION
## Summary
- remove the descriptive paragraph shown next to the competency radar legend to declutter the section

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbc20387f8832a9fc27d56ac7ecd54