### PR TITLE
Remove bullet lists from education timeline

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -658,6 +658,17 @@ li + li {
   color: var(--color-text-muted);
 }
 
+.timeline__details {
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.timeline__detail {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
 .timeline h4 {
   font-size: 0.95rem;
   margin-top: 1.6rem;

--- a/index.html
+++ b/index.html
@@ -324,10 +324,10 @@
               <p class="timeline__summary">
                 Ênfase em frameworks ágeis, governança de portfólio, planejamento estratégico e liderança de PMO para projetos de alta complexidade.
               </p>
-              <ul>
-                <li>Roadmap estratégico, PMBOK, WBS e gestão de riscos aplicada.</li>
-                <li>Gestão de mudanças, liderança de times híbridos e comunicação executiva.</li>
-              </ul>
+              <div class="timeline__details">
+                <p class="timeline__detail">Roadmap estratégico, PMBOK, WBS e gestão de riscos aplicada.</p>
+                <p class="timeline__detail">Gestão de mudanças, liderança de times híbridos e comunicação executiva.</p>
+              </div>
             </article>
 
             <article class="timeline__item">
@@ -339,10 +339,10 @@
               <p class="timeline__summary">
                 Formação com foco em fundamentos de desenvolvimento de software, estruturas de dados e arquitetura de sistemas.
               </p>
-              <ul>
-                <li>Prática em programação orientada a objetos, bancos de dados e infraestrutura.</li>
-                <li>Vivência em comunicação técnica, suporte a clientes e solução de problemas.</li>
-              </ul>
+              <div class="timeline__details">
+                <p class="timeline__detail">Prática em programação orientada a objetos, bancos de dados e infraestrutura.</p>
+                <p class="timeline__detail">Vivência em comunicação técnica, suporte a clientes e solução de problemas.</p>
+              </div>
             </article>
 
             <article class="timeline__item">
@@ -354,10 +354,10 @@
               <p class="timeline__summary">
                 Programa intensivo concluído com 100% de aproveitamento, cobrindo fundamentos da linguagem e automação de rotinas.
               </p>
-              <ul>
-                <li>Sintaxe, funções, estruturas condicionais e manipulação de dados.</li>
-                <li>Projetos práticos orientados a scripts e integração com APIs.</li>
-              </ul>
+              <div class="timeline__details">
+                <p class="timeline__detail">Sintaxe, funções, estruturas condicionais e manipulação de dados.</p>
+                <p class="timeline__detail">Projetos práticos orientados a scripts e integração com APIs.</p>
+              </div>
             </article>
 
             <article class="timeline__item">
@@ -369,10 +369,10 @@
               <p class="timeline__summary">
                 Desenvolvimento de aplicações web responsivas, manutenção de redes e fundamentos de gestão de projetos tecnológicos.
               </p>
-              <ul>
-                <li>Programação web, modelagem de banco de dados e design responsivo.</li>
-                <li>Gestão de cronogramas e documentação técnica para entregas acadêmicas.</li>
-              </ul>
+              <div class="timeline__details">
+                <p class="timeline__detail">Programação web, modelagem de banco de dados e design responsivo.</p>
+                <p class="timeline__detail">Gestão de cronogramas e documentação técnica para entregas acadêmicas.</p>
+              </div>
             </article>
 
             <article class="timeline__item">
@@ -384,10 +384,10 @@
               <p class="timeline__summary">
                 Base em engenharia de software, análise de requisitos e integração entre áreas de negócio e tecnologia.
               </p>
-              <ul>
-                <li>Metodologias de desenvolvimento, documentação e testes de sistemas.</li>
-                <li>Projeto integrador voltado à inovação em serviços digitais.</li>
-              </ul>
+              <div class="timeline__details">
+                <p class="timeline__detail">Metodologias de desenvolvimento, documentação e testes de sistemas.</p>
+                <p class="timeline__detail">Projeto integrador voltado à inovação em serviços digitais.</p>
+              </div>
             </article>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the education timeline bullet lists with plain text blocks to remove list styling
- add supporting timeline detail styles to preserve spacing and typography without bullets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe1cb1770832aa5b2e652fed6a9d1