### PR TITLE
Improve contrast for small typography

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -4,7 +4,8 @@
   --color-surface-alt: rgba(12, 16, 32, 0.85);
   --color-surface-strong: rgba(255, 255, 255, 0.05);
   --color-text: #f5f8ff;
-  --color-text-muted: rgba(229, 233, 255, 0.7);
+  --color-text-muted: rgba(229, 233, 255, 0.78);
+  --color-text-subtle: rgba(229, 233, 255, 0.62);
   --color-accent: #f6b73c;
   --color-accent-soft: rgba(246, 183, 60, 0.18);
   --color-border: rgba(255, 255, 255, 0.12);

--- a/css/components.css
+++ b/css/components.css
@@ -204,7 +204,7 @@
   margin-top: 1.6rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: rgba(229, 233, 255, 0.55);
+  color: var(--color-text-subtle);
 }
 
 .competency-grid {

--- a/css/layout.css
+++ b/css/layout.css
@@ -303,7 +303,7 @@
   font-size: 0.75rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: rgba(229, 233, 255, 0.52);
+  color: var(--color-text-subtle);
   margin-bottom: 0.5rem;
 }
 
@@ -344,7 +344,7 @@
   font-size: 0.78rem;
   letter-spacing: 0.32em;
   text-transform: uppercase;
-  color: rgba(229, 233, 255, 0.45);
+  color: var(--color-text-subtle);
 }
 
 .callout {


### PR DESCRIPTION
## Summary
- increase muted text contrast variables for the dark theme
- retarget small headline and label styles to a higher-contrast token to satisfy WCAG guidance

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68dbec68ecd8832a97206f91c99f3334