### PR TITLE
Fix mobile timeline dot alignment

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -106,13 +106,16 @@
   position: relative;
   display: grid;
   gap: 2.75rem;
+  --timeline-line-left: 22px;
+  --timeline-line-width: 2px;
+  --timeline-dot-size: 20px;
 }
 
 .timeline::before {
   content: '';
   position: absolute;
-  inset: 0 auto 0 22px;
-  width: 2px;
+  inset: 0 auto 0 var(--timeline-line-left);
+  width: var(--timeline-line-width);
   background: linear-gradient(180deg, rgba(246, 183, 60, 0.7), rgba(91, 128, 255, 0.2));
 }
 
@@ -133,10 +136,13 @@
   content: '';
   position: absolute;
   top: 6px;
-  left: 12px;
-  width: 20px;
-  height: 20px;
-  border-radius: 10px;
+  left: calc(
+    var(--timeline-line-left) - (var(--timeline-dot-size) / 2) +
+      (var(--timeline-line-width) / 2)
+  );
+  width: var(--timeline-dot-size);
+  height: var(--timeline-dot-size);
+  border-radius: 999px;
   border: 3px solid rgba(5, 8, 22, 0.85);
   background: linear-gradient(135deg, rgba(246, 183, 60, 0.9), rgba(91, 128, 255, 0.7));
   box-shadow: 0 0 0 6px rgba(246, 183, 60, 0.1);
@@ -670,8 +676,8 @@
     grid-template-columns: 1fr;
   }
 
-  .timeline::before {
-    left: 12px;
+  .timeline {
+    --timeline-line-left: 12px;
   }
 
   .timeline__item {
@@ -688,8 +694,8 @@
 }
 
 @media (max-width: 540px) {
-  .timeline::before {
-    left: 10px;
+  .timeline {
+    --timeline-line-left: 10px;
   }
 
   .timeline__item {


### PR DESCRIPTION
## Summary
- ensure the timeline marker stays centered by basing its offset on shared CSS variables
- adjust responsive breakpoints to update the timeline line position without breaking the marker alignment

## Testing
- Manual: Viewed the timeline section at 390px width

------
https://chatgpt.com/codex/tasks/task_e_68dc21976784832abf22156bfbc6c04d