### PR TITLE
Configure Vercel to serve static portfolio site

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "builds": [
+    { "src": "index.html", "use": "@vercel/static" },
+    { "src": "css/(.*)", "use": "@vercel/static" },
+    { "src": "js/(.*)", "use": "@vercel/static" },
+    { "src": "img/(.*)", "use": "@vercel/static" },
+    { "src": "public/(.*)", "use": "@vercel/static" }
+  ],
+  "routes": [
+    { "src": "/", "dest": "index.html" },
+    { "src": "/(.*)", "dest": "/$1" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration to treat the project as a static site
- ensure index.html and asset directories are deployed by the platform

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd10de03a0832aacdc3b67e9a567de