### PR TITLE
feat: destacar nova foto lateral na hero

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -265,13 +265,32 @@
 }
 
 .hero__panel {
-  background: var(--color-surface);
+  background-color: var(--color-surface);
+  background-image: url('../img/lateral_photo.png');
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: right center;
   border-radius: var(--radius-lg);
   padding: 2.5rem 2.25rem;
+  padding-right: clamp(2.25rem, 12vw, 15rem);
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: var(--shadow-panel);
   position: relative;
   overflow: hidden;
+}
+
+.hero__panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    rgba(5, 8, 22, 0.82) 0%,
+    rgba(5, 8, 22, 0.55) 45%,
+    rgba(5, 8, 22, 0) 72%
+  );
+  pointer-events: none;
+  z-index: 0;
 }
 
 .hero__panel::after {
@@ -282,6 +301,12 @@
   height: 220px;
   background: radial-gradient(circle, rgba(246, 183, 60, 0.28), transparent 65%);
   pointer-events: none;
+  z-index: 0;
+}
+
+.hero__panel > * {
+  position: relative;
+  z-index: 1;
 }
 
 .hero__avatar {
@@ -423,6 +448,12 @@
     justify-content: flex-start;
   }
 
+  .hero__panel {
+    background-size: 70%;
+    background-position: 95% center;
+    padding-right: clamp(2rem, 10vw, 12rem);
+  }
+
   .callout {
     flex-direction: column;
     align-items: flex-start;
@@ -451,6 +482,24 @@
     min-width: 0;
     width: 100%;
     justify-content: center;
+  }
+
+  .hero__panel {
+    background-size: 80%;
+    background-position: center bottom;
+    padding-top: 2rem;
+    padding-right: 1.75rem;
+    padding-bottom: clamp(10rem, 55vw, 14rem);
+    padding-left: 1.75rem;
+  }
+
+  .hero__panel::before {
+    background: linear-gradient(
+      180deg,
+      rgba(5, 8, 22, 0.82) 0%,
+      rgba(5, 8, 22, 0.52) 45%,
+      rgba(5, 8, 22, 0) 80%
+    );
   }
 }
 
@@ -496,6 +545,8 @@
 
   .hero__panel {
     padding: 2rem 1.75rem;
+    padding-right: clamp(1.75rem, 9vw, 10rem);
+    background-size: 75%;
   }
 
   .section {

--- a/index.html
+++ b/index.html
@@ -93,9 +93,6 @@
           </div>
 
           <aside class="hero__panel" aria-label="Informações rápidas">
-            <div class="hero__avatar">
-              <img src="img/profile_photo.png" alt="Foto de Leonardo Fonseca Pontes" />
-            </div>
             <ul class="hero__details">
               <li>
                 <span class="detail__label">Localização</span>


### PR DESCRIPTION
## Summary
- remove o avatar em imagem dentro do painel da hero
- aplica a nova foto transparente como background do painel com gradiente de contraste
- ajusta espaçamentos e breakpoints para manter a responsividade da hero

## Testing
- Manual QA - not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd1f4da838832ab6ba7d06c160788d