### PR TITLE
Fix language switcher flags and alignment

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -183,16 +183,22 @@
 
 .menu {
   display: flex;
-  gap: 1.5rem;
-  flex-wrap: wrap;
-  font-size: 0.95rem;
   align-items: center;
+  gap: clamp(1rem, 2vw, 1.6rem);
+  flex-wrap: nowrap;
+  margin-left: auto;
+  font-size: 0.95rem;
+}
+
+.menu > * {
+  flex-shrink: 0;
 }
 
 .menu a {
   color: var(--color-text-muted);
   font-weight: 500;
   letter-spacing: 0.02em;
+  white-space: nowrap;
 }
 
 .menu a:hover,
@@ -205,6 +211,8 @@
   align-items: center;
   gap: 0.5rem;
   margin-left: auto;
+  padding-left: clamp(1.5rem, 3vw, 3rem);
+  flex-shrink: 0;
 }
 
 .language-switcher__button {
@@ -223,9 +231,10 @@
   cursor: pointer;
   transition: border-color 180ms ease, background 180ms ease, color 180ms ease,
     box-shadow 180ms ease;
+  flex-shrink: 0;
 }
 
-.language-switcher__button span[aria-hidden='true'] {
+.language-switcher__flag {
   font-size: 1.05rem;
   line-height: 1;
 }
@@ -566,6 +575,7 @@
 
   .menu {
     width: 100%;
+    margin-left: 0;
     padding: 0.75rem 0 0.25rem;
     border-top: 1px solid rgba(255, 255, 255, 0.08);
     gap: 0.75rem;
@@ -590,6 +600,7 @@
     width: 100%;
     margin-left: 0;
     padding-top: 0.5rem;
+    padding-left: 0;
     border-top: 1px solid rgba(255, 255, 255, 0.08);
     justify-content: center;
     gap: 0.75rem;

--- a/index.html
+++ b/index.html
@@ -66,22 +66,24 @@
               type="button"
               class="language-switcher__button"
               data-language="pt-br"
+              data-flag="🇧🇷"
               title="Português"
               data-i18n-attrs="title:languagePortugueseTitle;aria-label:languagePortugueseLabel"
               aria-label="Português"
             >
-              <span aria-hidden="true">🇧🇷</span>
+              <span class="language-switcher__flag" aria-hidden="true">🇧🇷</span>
               <span class="language-switcher__label" data-i18n-key="languagePortugueseText">Português</span>
             </button>
             <button
               type="button"
               class="language-switcher__button"
               data-language="en"
+              data-flag="🇺🇸"
               title="English"
               data-i18n-attrs="title:languageEnglishTitle;aria-label:languageEnglishLabel"
               aria-label="English"
             >
-              <span aria-hidden="true">🇺🇸</span>
+              <span class="language-switcher__flag" aria-hidden="true">🇺🇸</span>
               <span class="language-switcher__label" data-i18n-key="languageEnglishText">English</span>
             </button>
           </div>

--- a/js/main.js
+++ b/js/main.js
@@ -93,6 +93,29 @@ import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES, translations } from './i18n.js';
 
   const languageButtons = Array.from(document.querySelectorAll('.language-switcher__button'));
 
+  const ensureLanguageButtonFlag = (button) => {
+    if (!(button instanceof HTMLElement)) {
+      return;
+    }
+
+    const flagSymbol = button.dataset.flag?.trim();
+    if (!flagSymbol) {
+      return;
+    }
+
+    let flagElement = button.querySelector('.language-switcher__flag');
+    if (!flagElement) {
+      flagElement = document.createElement('span');
+      flagElement.className = 'language-switcher__flag';
+      flagElement.setAttribute('aria-hidden', 'true');
+      button.insertBefore(flagElement, button.firstChild);
+    }
+
+    if (flagElement.textContent !== flagSymbol) {
+      flagElement.textContent = flagSymbol;
+    }
+  };
+
   const updateLanguageButtons = (lang) => {
     languageButtons.forEach((button) => {
       const isActive = button.dataset.language === lang;
@@ -128,6 +151,7 @@ import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES, translations } from './i18n.js';
     }
 
     updateLanguageButtons(normalized);
+    languageButtons.forEach(ensureLanguageButtonFlag);
     updateTopbarOffset();
 
     const dictionary = translations[normalized] || translations[DEFAULT_LANGUAGE] || {};
@@ -188,6 +212,7 @@ import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES, translations } from './i18n.js';
   }
 
   languageButtons.forEach((button) => {
+    ensureLanguageButtonFlag(button);
     button.addEventListener('click', () => {
       const targetLanguage = button.dataset.language;
       setLanguage(targetLanguage);


### PR DESCRIPTION
## Summary
- ensure the language toggle always renders country flags by adding flag metadata and a runtime fallback
- tighten the top navigation layout so the language toggle stays on the same line without wrapping links

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dd93fdc220832aa778aac0078e52c6