### PR TITLE
Refactor topbar layout and language selector styling

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -9,6 +9,10 @@
   --color-accent: #f6b73c;
   --color-accent-soft: rgba(246, 183, 60, 0.18);
   --color-border: rgba(255, 255, 255, 0.12);
+  --spacing-xs: 0.5rem;
+  --spacing-sm: 0.75rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
   --gradient-hero: radial-gradient(circle at 20% 20%, rgba(246, 183, 60, 0.25), transparent 55%),
     radial-gradient(circle at 80% 0%, rgba(72, 113, 248, 0.3), transparent 55%),
     linear-gradient(135deg, rgba(9, 12, 28, 0.95), rgba(5, 8, 22, 0.95));

--- a/css/layout.css
+++ b/css/layout.css
@@ -9,10 +9,11 @@
 
 .topbar__inner {
   display: flex;
-  align-items: center;
   justify-content: space-between;
+  align-items: center;
+  gap: var(--spacing-md);
   padding: 1.25rem 0;
-  gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .topbar__toggle {
@@ -80,21 +81,29 @@
   transform: translateY(-6px) rotate(-45deg);
 }
 
-.brand {
+.topbar__brand {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--spacing-sm);
+  padding-block: 0.25rem;
+}
+
+.topbar__brand-info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
 }
 
 .brand__monogram {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 48px;
-  height: 48px;
-  border-radius: 16px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
   overflow: hidden;
-  border: 2px solid rgba(255, 255, 255, 0.08);
+  border: 2px solid rgba(255, 255, 255, 0.12);
   background: linear-gradient(135deg, rgba(246, 183, 60, 0.32), rgba(91, 128, 255, 0.32));
 }
 
@@ -179,85 +188,98 @@
   margin: 0;
   font-size: 0.9rem;
   color: var(--color-text-muted);
+  line-height: 1.4;
 }
 
-.menu {
+.topbar__nav {
   display: flex;
   align-items: center;
-  gap: clamp(1rem, 2vw, 1.6rem);
-  flex-wrap: nowrap;
-  margin-left: auto;
+  justify-content: center;
+  flex: 1 1 auto;
+  gap: var(--spacing-md);
+  flex-wrap: wrap;
   font-size: 0.95rem;
+  min-width: 0;
+  padding-block: 0.25rem;
 }
 
-.menu > * {
+.topbar__nav > * {
   flex-shrink: 0;
 }
 
-.menu a {
+.topbar__nav a {
   color: var(--color-text-muted);
   font-weight: 500;
   letter-spacing: 0.02em;
   white-space: nowrap;
+  padding-block: 0.25rem;
 }
 
-.menu a:hover,
-.menu a:focus {
+.topbar__nav a:hover,
+.topbar__nav a:focus {
   color: var(--color-text);
 }
 
-.language-switcher {
-  display: inline-flex;
+.topbar__lang-switch {
+  display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.25rem;
   margin-left: auto;
-  padding-left: clamp(1.5rem, 3vw, 3rem);
-  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.language-switcher {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
 }
 
 .language-switcher__button {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 0.35rem;
-  padding: 0.4rem 0.65rem;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(12, 16, 32, 0.7);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(229, 233, 255, 0.28);
+  background: none;
   color: var(--color-text-muted);
-  font-size: 0.85rem;
+  font-size: 0.875rem;
   font-weight: 500;
   letter-spacing: 0.02em;
-  line-height: 1;
+  line-height: 1.2;
   cursor: pointer;
-  transition: border-color 180ms ease, background 180ms ease, color 180ms ease,
-    box-shadow 180ms ease;
+  transition: color 180ms ease, border-color 180ms ease,
+    background-color 180ms ease, box-shadow 180ms ease;
   flex-shrink: 0;
 }
 
 .language-switcher__flag {
-  font-size: 1.05rem;
-  line-height: 1;
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
 }
 
 .language-switcher__button:hover,
 .language-switcher__button:focus-visible {
   border-color: rgba(246, 183, 60, 0.65);
-  background: rgba(12, 16, 32, 0.9);
+  background-color: rgba(12, 16, 32, 0.6);
   color: var(--color-text);
-  outline: none;
-  box-shadow: 0 12px 28px rgba(9, 12, 28, 0.45);
 }
 
 .language-switcher__button:focus-visible {
-  box-shadow: 0 0 0 3px rgba(246, 183, 60, 0.4);
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(246, 183, 60, 0.35);
 }
 
 .language-switcher__button[aria-pressed='true'],
-.language-switcher__button.is-active {
-  border-color: rgba(91, 128, 255, 0.7);
-  background: rgba(20, 26, 52, 0.9);
+.language-switcher__button.is-active,
+.language-switcher__button.active {
+  border-color: rgba(91, 128, 255, 0.6);
+  background-color: var(--color-surface-alt);
   color: var(--color-text);
-  box-shadow: 0 10px 24px rgba(10, 17, 42, 0.45);
+  box-shadow: 0 10px 24px rgba(10, 17, 42, 0.35);
 }
 
 .language-switcher__label {
@@ -288,6 +310,30 @@
 }
 
 @media (max-width: 768px) {
+  .topbar__nav {
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+    margin-top: var(--spacing-sm);
+    padding-top: var(--spacing-sm);
+    gap: var(--spacing-sm);
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    justify-content: flex-start;
+  }
+
+  .topbar__lang-switch {
+    order: -1;
+    width: 100%;
+    justify-content: flex-end;
+    margin-left: 0;
+    padding-bottom: var(--spacing-xs);
+  }
+
+  .language-switcher {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
   .hero__inner {
     grid-template-columns: 1fr;
   }
@@ -501,11 +547,10 @@
 @media (max-width: 960px) {
   .topbar__inner {
     flex-wrap: wrap;
-    align-items: center;
-    gap: 0.75rem 1rem;
+    gap: var(--spacing-sm);
   }
 
-  .menu {
+  .topbar__nav {
     justify-content: flex-start;
   }
 
@@ -545,37 +590,28 @@
     display: inline-flex;
   }
 
-  .menu {
-    width: 100%;
-    margin-left: 0;
-    padding: 0.75rem 0 0.25rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
-    gap: 0.75rem;
-    flex-direction: column;
-  }
-
-  .menu[data-visible='false'] {
+  .topbar__nav {
     display: none;
   }
 
-  .menu[data-visible='true'] {
-    display: grid;
+  .topbar__nav[data-visible='true'] {
+    display: flex;
   }
 
-  .menu a {
+  .topbar__nav a {
     display: block;
     width: 100%;
-    padding: 0.5rem 0;
+  }
+
+  .topbar__lang-switch {
+    justify-content: center;
+    margin-bottom: var(--spacing-xs);
+    padding-bottom: 0;
   }
 
   .language-switcher {
-    width: 100%;
-    margin-left: 0;
-    padding-top: 0.5rem;
-    padding-left: 0;
-    border-top: 1px solid rgba(255, 255, 255, 0.08);
     justify-content: center;
-    gap: 0.75rem;
+    gap: var(--spacing-sm);
   }
 
   .language-switcher__button {
@@ -602,14 +638,13 @@
 }
 
 @media (max-width: 540px) {
-  .brand {
+  .topbar__brand {
     gap: 0.75rem;
   }
 
   .brand__monogram {
-    width: 44px;
-    height: 44px;
-    border-radius: 14px;
+    width: 40px;
+    height: 40px;
   }
 
   .brand__name {

--- a/img/flag-brazil.svg
+++ b/img/flag-brazil.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 28" role="img" aria-labelledby="title">
+  <title>Bandeira do Brasil</title>
+  <rect width="40" height="28" fill="#009b3a" rx="4" />
+  <polygon points="20,4 36,14 20,24 4,14" fill="#ffdf00" />
+  <circle cx="20" cy="14" r="7" fill="#002776" />
+  <path
+    d="M14 15.4c3.4-2.6 8.2-2.6 11.6 0"
+    fill="none"
+    stroke="#f5f8ff"
+    stroke-width="1.2"
+    stroke-linecap="round"
+  />
+</svg>

--- a/img/flag-usa.svg
+++ b/img/flag-usa.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 28" role="img" aria-labelledby="title">
+  <title>Flag of the United States</title>
+  <rect width="40" height="28" fill="#b22234" rx="4" />
+  <g fill="#fff">
+    <rect y="4" width="40" height="2" />
+    <rect y="8" width="40" height="2" />
+    <rect y="12" width="40" height="2" />
+    <rect y="16" width="40" height="2" />
+    <rect y="20" width="40" height="2" />
+    <rect y="24" width="40" height="2" />
+  </g>
+  <rect width="18" height="14" fill="#3c3b6e" rx="2" />
+  <g fill="#fff" transform="translate(2 2)">
+    <circle cx="2" cy="2" r="0.7" />
+    <circle cx="6" cy="2" r="0.7" />
+    <circle cx="10" cy="2" r="0.7" />
+    <circle cx="14" cy="2" r="0.7" />
+    <circle cx="4" cy="5" r="0.7" />
+    <circle cx="8" cy="5" r="0.7" />
+    <circle cx="12" cy="5" r="0.7" />
+    <circle cx="2" cy="8" r="0.7" />
+    <circle cx="6" cy="8" r="0.7" />
+    <circle cx="10" cy="8" r="0.7" />
+    <circle cx="14" cy="8" r="0.7" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -22,11 +22,11 @@
   <body>
     <header class="topbar">
       <div class="container topbar__inner">
-        <div class="brand">
+        <div class="topbar__brand">
           <span class="brand__monogram">
             <img src="img/profile_photo.png" alt="Foto de Leonardo Fonseca Pontes" data-i18n-attrs="alt:brandPhotoAlt" />
           </span>
-          <div>
+          <div class="topbar__brand-info">
             <a class="brand__name" href="#inicio" data-i18n-key="brandName">Leonardo Fonseca Pontes</a>
             <p class="brand__role" data-i18n-key="brandRole">Gerente de Projetos · Transformação Digital</p>
           </div>
@@ -43,7 +43,7 @@
           <span class="topbar__toggle-icon" aria-hidden="true"></span>
         </button>
         <nav
-          class="menu"
+          class="topbar__nav"
           id="primary-nav"
           aria-label="Navegação principal"
           data-visible="false"
@@ -56,38 +56,46 @@
           <a href="#certificacoes" data-i18n-key="navCertifications">Certificações</a>
           <a href="#depoimentos" data-i18n-key="navTestimonials">Depoimentos</a>
           <a href="#contato" data-i18n-key="navContact">Contato</a>
-          <div
-            class="language-switcher"
-            role="group"
-            data-i18n-attrs="aria-label:languageSwitcherAria"
-            aria-label="Selecionar idioma"
-          >
-            <button
-              type="button"
-              class="language-switcher__button"
-              data-language="pt-br"
-              data-flag="🇧🇷"
-              title="Português"
-              data-i18n-attrs="title:languagePortugueseTitle;aria-label:languagePortugueseLabel"
-              aria-label="Português"
-            >
-              <span class="language-switcher__flag" aria-hidden="true">🇧🇷</span>
-              <span class="language-switcher__label" data-i18n-key="languagePortugueseText">Português</span>
-            </button>
-            <button
-              type="button"
-              class="language-switcher__button"
-              data-language="en"
-              data-flag="🇺🇸"
-              title="English"
-              data-i18n-attrs="title:languageEnglishTitle;aria-label:languageEnglishLabel"
-              aria-label="English"
-            >
-              <span class="language-switcher__flag" aria-hidden="true">🇺🇸</span>
-              <span class="language-switcher__label" data-i18n-key="languageEnglishText">English</span>
-            </button>
-          </div>
         </nav>
+        <div
+          class="topbar__lang-switch language-switcher"
+          role="group"
+          aria-label="Selecionar idioma"
+          data-i18n-attrs="aria-label:languageSwitcherAria"
+        >
+          <button
+            type="button"
+            class="language-switcher__button"
+            data-language="pt-br"
+            title="Portuguese"
+            data-i18n-attrs="title:languagePortugueseTitle;aria-label:languagePortugueseLabel"
+            aria-label="Português"
+          >
+            <img
+              class="language-switcher__flag"
+              src="img/flag-brazil.svg"
+              alt="Bandeira do Brasil"
+              title="Bandeira do Brasil"
+            />
+            <span class="language-switcher__label" data-i18n-key="languagePortugueseText">Português</span>
+          </button>
+          <button
+            type="button"
+            class="language-switcher__button"
+            data-language="en"
+            title="English"
+            data-i18n-attrs="title:languageEnglishTitle;aria-label:languageEnglishLabel"
+            aria-label="English"
+          >
+            <img
+              class="language-switcher__flag"
+              src="img/flag-usa.svg"
+              alt="Flag of the United States"
+              title="Flag of the United States"
+            />
+            <span class="language-switcher__label" data-i18n-key="languageEnglishText">English</span>
+          </button>
+        </div>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary
- restructure the topbar markup into distinct brand, navigation, and language switch regions
- add spacing tokens and updated flexbox rules so the header has breathing room and mobile-friendly behaviour
- restyle the language toggle with subtler buttons and embedded SVG flag icons

## Testing
- Manual QA: Opened `index.html` via `python -m http.server` and verified the new header layout

------
https://chatgpt.com/codex/tasks/task_e_68dd9a3af338832a8e79c4af7f496951