### PR TITLE
Atualiza herói com nova imagem de fundo e layout

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -292,11 +292,42 @@
 }
 
 .hero {
+  position: relative;
+  overflow: hidden;
   padding: 5.5rem 0 4rem;
   background: var(--gradient-hero);
 }
 
+.hero__background {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-image: url("../img/lateral_photo.png");
+  background-size: cover;
+  background-position: center right;
+  opacity: 0.15;
+  z-index: 0;
+}
+
+.hero__background::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+      120deg,
+      rgba(5, 8, 22, 0.92) 0%,
+      rgba(5, 8, 22, 0.82) 35%,
+      rgba(5, 8, 22, 0.6) 55%,
+      rgba(5, 8, 22, 0.45) 100%
+    );
+  pointer-events: none;
+}
+
 .hero__inner {
+  position: relative;
+  z-index: 1;
   display: grid;
   gap: clamp(2rem, 4vw, 3rem);
   align-items: start;
@@ -305,7 +336,7 @@
 
 @media (min-width: 960px) {
   .hero__inner {
-    grid-template-columns: minmax(0, 1fr) auto 280px;
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
   }
 }
 
@@ -338,32 +369,13 @@
     grid-template-columns: 1fr;
   }
 
-  .hero__photo,
-  .hero__panel {
-    margin-top: 1.5rem;
-  }
-
-  .hero__photo {
-    justify-self: center;
-  }
-
   .hero__panel {
     justify-self: center;
   }
 }
 
-.hero__photo {
-  align-self: start;
-  justify-self: center;
-}
-
-.hero__photo img {
-  display: block;
-  width: clamp(200px, 22vw, 260px);
-  max-width: 100%;
-  height: auto;
-  border-radius: var(--radius-md);
-  box-shadow: 0 18px 40px rgba(5, 8, 22, 0.35);
+.hero__profile {
+  padding: clamp(2rem, 4vw, 3rem);
 }
 
 .hero__profile h1 {
@@ -405,15 +417,22 @@
 }
 
 .hero__panel {
-  background-color: var(--color-surface);
+  background-color: rgba(9, 16, 46, 0.9);
   border-radius: var(--radius-lg);
-  padding: 2.25rem 2rem;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: var(--shadow-panel);
   width: 100%;
-  max-width: 280px;
+  max-width: 320px;
   align-self: start;
   justify-self: center;
+  margin-top: clamp(1.5rem, 4vw, 2rem);
+}
+
+@media (min-width: 960px) {
+  .hero__panel {
+    margin-top: 0;
+  }
 }
 
 .hero__avatar {

--- a/index.html
+++ b/index.html
@@ -101,6 +101,7 @@
 
     <main>
       <section id="inicio" class="hero">
+        <div class="hero__background" aria-hidden="true"></div>
         <div class="container hero__inner">
           <div class="hero__profile">
             <span class="hero__badge" data-i18n-key="heroBadge">Disponível para liderar projetos estratégicos</span>
@@ -134,10 +135,6 @@
                 <p class="stat-card__label" data-i18n-key="statPillarsLabel">Estratégia · Agilidade · Entrega de valor</p>
               </article>
             </div>
-          </div>
-
-          <div class="hero__photo">
-            <img src="img/profile_photo.png" alt="Foto de Leonardo Fonseca Pontes" data-i18n-attrs="alt:heroPhotoAlt" />
           </div>
 
           <aside class="hero__panel" aria-label="Informações rápidas" data-i18n-attrs="aria-label:heroPanelAria">


### PR DESCRIPTION
## Summary
- reposiciona a foto do herói como camada de fundo decorativa com gradiente para manter contraste adequado
- ajusta o grid do herói, o espaçamento do perfil e a largura do painel lateral para evitar compressão do texto

## Testing
- não aplicável

------
https://chatgpt.com/codex/tasks/task_e_68dd9cffbacc832a907853cf8d8cdd3d