### PR TITLE
Adjust hero background layout

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -298,30 +298,23 @@
   background: var(--gradient-hero);
 }
 
-.hero__background {
+.hero__bg {
   position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
-  left: 0;
-  background-image: url("../img/lateral_photo.png");
-  background-size: cover;
-  background-position: center right;
-  opacity: 0.15;
-  z-index: 0;
-}
-
-.hero__background::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
+  width: 408px;
+  background-image: linear-gradient(
       120deg,
-      rgba(5, 8, 22, 0.92) 0%,
-      rgba(5, 8, 22, 0.82) 35%,
-      rgba(5, 8, 22, 0.6) 55%,
-      rgba(5, 8, 22, 0.45) 100%
-    );
+      rgba(5, 8, 22, 0.9) 0%,
+      rgba(5, 8, 22, 0.75) 45%,
+      rgba(5, 8, 22, 0.35) 100%
+    ),
+    url("../img/lateral_photo.png");
+  background-repeat: no-repeat, no-repeat;
+  background-size: 100% 100%, auto;
+  background-position: center, right top;
+  z-index: 0;
   pointer-events: none;
 }
 
@@ -329,14 +322,14 @@
   position: relative;
   z-index: 1;
   display: grid;
-  gap: clamp(2rem, 4vw, 3rem);
+  grid-template-columns: minmax(0, 2fr) minmax(220px, 320px);
+  gap: clamp(var(--spacing-lg), 4vw, 3rem);
   align-items: start;
-  grid-template-columns: minmax(0, 1fr);
 }
 
-@media (min-width: 960px) {
+@media (max-width: 960px) {
   .hero__inner {
-    grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
@@ -365,8 +358,8 @@
     justify-content: flex-end;
   }
 
-  .hero__inner {
-    grid-template-columns: 1fr;
+  .hero__bg {
+    display: none;
   }
 
   .hero__panel {

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
 
     <main>
       <section id="inicio" class="hero">
-        <div class="hero__background" aria-hidden="true"></div>
+        <div class="hero__bg" aria-hidden="true"></div>
         <div class="container hero__inner">
           <div class="hero__profile">
             <span class="hero__badge" data-i18n-key="heroBadge">Disponível para liderar projetos estratégicos</span>


### PR DESCRIPTION
## Summary
- replace the hero background container with a dedicated `.hero__bg` element layered behind the content
- style the new background wrapper to show `lateral_photo.png` at its natural width with a gradient overlay and responsive hiding on small screens
- update the hero grid layout to keep content above the background and collapse cleanly on narrow viewports

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dda0c0b9c4832a9a9ac69bd340a3a6