### PR TITLE
Refine quick actions and enhance footer social links

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -601,10 +601,8 @@
 
 .footer__content {
   display: flex;
-  flex-direction: column;
-  align-items: center;
   justify-content: center;
-  gap: 0.75rem;
+  align-items: center;
   text-align: center;
 }
 
@@ -612,6 +610,51 @@
   margin: 0;
   color: rgba(229, 233, 255, 0.75);
   font-size: 0.95rem;
+}
+
+.footer__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.footer__text {
+  margin: 0;
+}
+
+.footer__social {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.footer__icon-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  background: rgba(246, 183, 60, 0.1);
+  border: 1px solid rgba(246, 183, 60, 0.35);
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease,
+    background-color 180ms ease;
+}
+
+.footer__icon-link:hover,
+.footer__icon-link:focus-visible {
+  background: rgba(246, 183, 60, 0.2);
+  border-color: rgba(246, 183, 60, 0.6);
+  box-shadow: 0 10px 20px rgba(246, 183, 60, 0.2);
+  transform: translateY(-2px);
+  outline: none;
+}
+
+.footer__icon {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
 }
 
 @media (max-width: 960px) {

--- a/index.html
+++ b/index.html
@@ -149,20 +149,6 @@
               <span class="quick-action-card__label" data-i18n-key="detailLocationLabel">Localização</span>
               <span class="quick-action-card__title" data-i18n-key="detailLocationValue">Ribeirão Preto · São Paulo · Brasil</span>
             </article>
-            <a class="quick-action-card" href="tel:+5516991091234" role="listitem">
-              <span class="quick-action-card__label" data-i18n-key="detailPhoneLabel">Contato</span>
-              <span class="quick-action-card__title" data-i18n-key="detailPhoneValue">+55 16 99109-1234</span>
-              <span class="quick-action-card__description" data-i18n-key="quickActionsPhoneDescription">
-                Disponível para conversas sobre liderança de projetos estratégicos.
-              </span>
-            </a>
-            <a class="quick-action-card" href="mailto:leonfpontes@gmail.com" role="listitem">
-              <span class="quick-action-card__label" data-i18n-key="detailEmailLabel">E-mail</span>
-              <span class="quick-action-card__title" data-i18n-key="detailEmailValue">leonfpontes@gmail.com</span>
-              <span class="quick-action-card__description" data-i18n-key="quickActionsEmailDescription">
-                Retorno em até 24 horas úteis com os próximos passos da conversa.
-              </span>
-            </a>
             <a
               class="quick-action-card quick-action-card--ghost"
               href="https://www.linkedin.com/in/leonardo-fonseca-pontes-465740103"
@@ -176,10 +162,6 @@
                 Conecte-se para acompanhar projetos, publicações e oportunidades de colaboração.
               </span>
             </a>
-            <article class="quick-action-card" role="listitem">
-              <span class="quick-action-card__label" data-i18n-key="detailLanguagesLabel">Idiomas</span>
-              <span class="quick-action-card__title" data-i18n-key="detailLanguagesValue">Português (Nativo) · Inglês (Avançado · Não nativo)</span>
-            </article>
           </div>
         </div>
       </section>
@@ -811,11 +793,31 @@
 
     <footer class="footer">
       <div class="container footer__content">
-        <p>
-          &copy; <span id="year"></span>
-          <span data-i18n-key="footerOwner">Leonardo Fonseca Pontes</span>.
-          <span data-i18n-key="footerRights">Todos os direitos reservados.</span>
-        </p>
+        <div class="footer__meta">
+          <p class="footer__text">
+            &copy; <span id="year"></span>
+            <span data-i18n-key="footerOwner">Leonardo Fonseca Pontes</span>.
+            <span data-i18n-key="footerRights">Todos os direitos reservados.</span>
+          </p>
+          <div class="footer__social" aria-label="Redes sociais">
+            <a
+              class="footer__icon-link"
+              href="https://api.whatsapp.com/send/?phone=5516991091234&text=Ol%C3%A1%2C+vi+seu+portf%C3%B3lio+e+gostaria+de+conversar+sobre+uma+oportunidade.&type=phone_number&app_absent=0"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img class="footer__icon" src="img/whatsapp--v2.png" alt="Conversar pelo WhatsApp" />
+            </a>
+            <a
+              class="footer__icon-link"
+              href="https://www.linkedin.com/in/leonardo-fonseca-pontes-465740103/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img class="footer__icon" src="img/linkedin.png" alt="Visitar o LinkedIn" />
+            </a>
+          </div>
+        </div>
       </div>
     </footer>
 


### PR DESCRIPTION
## Summary
- remove redundant contact, email, and language cards from the quick actions "Sobre mim" grid to streamline the section
- add WhatsApp and LinkedIn social icons alongside the existing copyright text in the footer
- style the new footer layout and icon buttons to match the site's visual language

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68deb1aeaef4832aa7d49a08beb31b85