### PR TITLE
Remove Sobre mim section and align footer icons

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -603,7 +603,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  text-align: center;
 }
 
 .footer__content p {
@@ -613,10 +612,13 @@
 }
 
 .footer__meta {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 1rem;
   flex-wrap: wrap;
+  width: 100%;
+  justify-content: space-between;
+  text-align: left;
 }
 
 .footer__text {

--- a/index.html
+++ b/index.html
@@ -135,37 +135,6 @@
         </div>
       </section>
 
-      <section class="section section--quick-actions" aria-labelledby="quick-actions-title">
-        <div class="container section__content quick-actions__content">
-          <header class="section__header quick-actions__header">
-            <span class="section__eyebrow" data-i18n-key="quickActionsEyebrow">Conexões</span>
-            <h2 id="quick-actions-title" data-i18n-key="quickActionsTitle">Sobre mim</h2>
-            <p data-i18n-key="quickActionsDescription">
-              Conheça os principais dados de contato, localização e idiomas para seguirmos com novos projetos.
-            </p>
-          </header>
-          <div class="quick-actions__grid" role="list">
-            <article class="quick-action-card" role="listitem">
-              <span class="quick-action-card__label" data-i18n-key="detailLocationLabel">Localização</span>
-              <span class="quick-action-card__title" data-i18n-key="detailLocationValue">Ribeirão Preto · São Paulo · Brasil</span>
-            </article>
-            <a
-              class="quick-action-card quick-action-card--ghost"
-              href="https://www.linkedin.com/in/leonardo-fonseca-pontes-465740103"
-              target="_blank"
-              rel="noopener noreferrer"
-              role="listitem"
-            >
-              <span class="quick-action-card__label" data-i18n-key="detailLinkedinLabel">LinkedIn</span>
-              <span class="quick-action-card__title" data-i18n-key="detailLinkedinValue">/in/leonardo-fonseca-pontes</span>
-              <span class="quick-action-card__description" data-i18n-key="quickActionsLinkedinDescription">
-                Conecte-se para acompanhar projetos, publicações e oportunidades de colaboração.
-              </span>
-            </a>
-          </div>
-        </div>
-      </section>
-
       <section id="resumo" class="section">
         <div class="container section__content">
           <header class="section__header">


### PR DESCRIPTION
## Summary
- remove the "Sobre mim" quick actions section from the home page
- adjust footer layout so the social icons align with the right padding of the page

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68deb3c52518832a9d4035f15d125264