### PR TITLE
Centralize footer text

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -973,8 +973,8 @@
   gap: 1rem;
   flex-wrap: wrap;
   width: 100%;
-  justify-content: space-between;
-  text-align: left;
+  justify-content: center;
+  text-align: center;
 }
 
 .footer__text {


### PR DESCRIPTION
## Summary
- center the footer meta content to align the text in the middle of the page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e034f429d0832aa9367cb51dbd047f