### PR TITLE
Add Google Analytics tracking tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,17 @@
     <link rel="stylesheet" href="css/base.css" />
     <link rel="stylesheet" href="css/layout.css" />
     <link rel="stylesheet" href="css/components.css" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-843HEPMCYR"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+
+      gtag('config', 'G-843HEPMCYR');
+    </script>
   </head>
   <body>
     <header class="topbar">


### PR DESCRIPTION
## Summary
- add the Google Analytics gtag.js snippet to the site's head to enable tracking

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e54bdf031c832a92caa05080d47c61